### PR TITLE
Use `--no-index` to avoid `git diff` warning

### DIFF
--- a/src/index.sh
+++ b/src/index.sh
@@ -13,7 +13,7 @@ git_head=$INPUT_HEAD
 
 # https://github.com/actions/runner/issues/342
 # get names of files from PR (excluding deleted files)
-git diff --name-only --diff-filter=db "$git_base".."$git_head" > ../pr-changes.txt
+git diff --no-index --name-only --diff-filter=db "$git_base".."$git_head" > ../pr-changes.txt
 
 # Find modified shell scripts
 list_of_changes=()


### PR DESCRIPTION
`--no-index` is required to avoid warnings like:

```
warning: Not a git repository. Use --no-index to compare two paths outside a working tree
```