### PR TITLE
Fix wrong check in `clean_array()`

### DIFF
--- a/src/functions.sh
+++ b/src/functions.sh
@@ -73,7 +73,7 @@ file_to_array () {
 # $@ - source array
 # $? - return value - 0 when succes
 clean_array () {
-  [ $# -le 2 ] && return 1
+  [ $# -le 1 ] && return 1
   local output="$1"
   shift
   local input=("$@")


### PR DESCRIPTION
Check should be: `$# -le 1` since there might be array of length `1`, when only one file was changed.