### PR TITLE
Action cannot be run on `push`

### DIFF
--- a/.github/workflows/shellcheck_test.yml
+++ b/.github/workflows/shellcheck_test.yml
@@ -1,23 +1,17 @@
 name: Test Differential ShellCheck
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
 
 jobs:
   shellCheck:
     runs-on: ubuntu-20.04
-    defaults:
-      run:
-        shell: bash
 
     steps:   
       - name: Repository checkout
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}  
 
       - name: Differential ShellCheck
         uses: ./

--- a/README.md
+++ b/README.md
@@ -25,13 +25,11 @@ To evaluate results Differential ShellCheck uses utilities `csdiff` and `csgrep`
 
 ## Usage
 
-Example of running Differential ShellCheck on commits and pull requests on `main` branch.
+Example of running Differential ShellCheck on pull requests on `main` branch.
 
 ```yml
 name: Differential ShellCheck
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
 
@@ -105,3 +103,7 @@ Path to text file which holds a list of shell scripts in this repository which w
 * example: [.diff-shellcheck-scripts.txt](.github/.diff-shellcheck-scripts.txt)
 
 *Note: Every path should be absolute and placed on separate lines. Avoid spaces in list since they are counted as comment.*
+
+## Limitations
+
+* Currently `differential-shellcheck` action could be run only on Pull-Requests


### PR DESCRIPTION
Currently ` differential-shellcheck` doesn'ŧ support `push` events.

*Note: Since `github.event.pull_request.base.sha` and `github.event.pull_request.head.sha` aren't available on `push`.*