### PR TITLE
Add support for job summaries :bookmark_tabs: 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Add option to run in debug mode - more verbose output
 * Output optimizations - cleaner output, emojis, updated colors and spacing
+* Support for job summaries
 
 ## v2.1.1
 

--- a/README.md
+++ b/README.md
@@ -21,9 +21,10 @@ To evaluate results Differential ShellCheck uses utilities `csdiff` and `csgrep`
 * Shell scripts auto-detection based on shebangs (`!#/bin/sh` or `!#/bin/bash`) and file extensions (`.sh`)
 * Ability to white list specific error codes
 * Statistics about fixed and added errors
-* Colored console output
+* Colored console output with emojis
 * [SARIF support](https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning) - warnings are visible in `Changed files` tab of Pull-Request
 * Ability to run in verbose mode when run with [debug option](https://github.blog/changelog/2022-05-24-github-actions-re-run-jobs-with-debug-logging/)
+* Results displayed as [job summaries](https://github.blog/2022-05-09-supercharging-github-actions-with-job-summaries/)
 
 ## Usage
 

--- a/src/functions.sh
+++ b/src/functions.sh
@@ -113,6 +113,31 @@ uploadSARIF () {
   fi
 }
 
+summary () {
+  local fixed_issues
+  fixed_issues=$(grep -Eo "[0-9]*" < <(csgrep --mode=stat ../fixes.log))
+
+  local added_issues
+  added_issues=$(grep -Eo "[0-9]*" < <(csgrep --mode=stat ../bugs.log))
+
+  echo -e "\
+### Differential ShellCheck 🐚
+
+Changed scripts: \`${#list_of_changed_scripts[@]}\`
+
+|                             | ❌ Added | ✅ Fixed |
+|:---------------------------:|:-------:|:-------:|
+| ⚠️ [Errors / Warnings / Notes](https://github.com/${GITHUB_REPOSITORY}/pull/${GITHUB_REF//merge}/files) |  **${added_issues:-0}**  |  **${fixed_issues:-0}**  |
+
+#### Useful links
+
+- [Differential ShellCheck Documentation](https://github.com/redhat-plumbers-in-action/differential-shellcheck#readme)
+- [ShellCheck Documentation](https://github.com/koalaman/shellcheck#readme)
+
+---
+_ℹ️ When you have an issue with GitHub action please try to run it in [debug mode](https://github.blog/changelog/2022-05-24-github-actions-re-run-jobs-with-debug-logging/) and submit an [issue](https://github.com/redhat-plumbers-in-action/differential-shellcheck/issues/new)._"
+}
+
 # Logging aliases, use echo -e to use them
 export MAIN_HEADING="\
 \n\n:::::::::::::::::::::::::::::::\n\


### PR DESCRIPTION
Example of Differential ShellCheck job summary:

### Differential ShellCheck 🐚

Changed scripts: `2`

|                             | ❌ Added | ✅ Fixed |
|:---------------------------:|:-------:|:-------:|
| ⚠️ [Errors / Warnings / Notes](https://github.com/redhat-plumbers-in-action/differential-shellcheck/pull/41/files) |  **1**  |  **0**  |

#### Useful links

- [Differential ShellCheck Documentation](https://github.com/redhat-plumbers-in-action/differential-shellcheck#readme)
- [ShellCheck Documentation](https://github.com/koalaman/shellcheck#readme)

---
_ℹ️ When you have an issue with GitHub action please try to run it in [debug mode](https://github.blog/changelog/2022-05-24-github-actions-re-run-jobs-with-debug-logging/) and submit an [issue](https://github.com/redhat-plumbers-in-action/differential-shellcheck/issues/new)._