### PR TITLE
Add support for `.bash` extensions :champagne: 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Add option to run in debug mode - more verbose output
 * Output optimizations - cleaner output, emojis, updated colors and spacing
 * Support for job summaries
+* Add support for `.bash` extensions
 
 ## v2.1.1
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ To evaluate results Differential ShellCheck uses utilities `csdiff` and `csgrep`
 
 ## Features
 
-* Shell scripts auto-detection based on shebangs (`!#/bin/sh` or `!#/bin/bash`) and file extensions (`.sh`)
+* Shell scripts auto-detection based on shebangs (`!#/bin/sh` or `!#/bin/bash`) and file extensions (`.sh`, `.bash`)
 * Ability to white list specific error codes
 * Statistics about fixed and added errors
 * Colored console output with emojis

--- a/src/functions.sh
+++ b/src/functions.sh
@@ -13,14 +13,18 @@ is_it_script () {
 }
 
 # Function to check if given file has .sh extension
-# https://stackoverflow.com/a/407229
+# https://stackoverflow.com/a/6926061
 # $1 - <string> absolute path to file
 # $? - return value - 0 when succes
 check_extension () {
   [ $# -le 0 ] && return 1
   local file="$1"
 
-  [ "${file: -3}" == ".sh" ] && return 0 || return 2
+  case $file in
+    *.sh) return 0;;
+    *.bash) return 0;;
+    *) return 2
+  esac
 }
 
 # Function to check if given file contain shell shebang (bash or sh)


### PR DESCRIPTION
Files ending with `.bash` will be automatically verified by differential-shellcheck