### PR TITLE
Fix tool name in SARIF reports

### DIFF
--- a/src/index.sh
+++ b/src/index.sh
@@ -96,7 +96,10 @@ fi
 if [ -n "$INPUT_TOKEN" ]; then
   echo
   # GitHub requires an absolute path, so let's remove the './' prefix from it.
-  csgrep --strip-path-prefix './' --mode=sarif ../bugs.log >> output.sarif && uploadSARIF
+  csgrep --strip-path-prefix './' --mode=sarif ../bugs.log | \
+    # csgrep reports 'csdiff' as the tool that has generated the reports, so
+    # change it to 'ShellCheck' instead.
+    sed 's/"csdiff"/"ShellCheck"/' >> output.sarif && uploadSARIF
 fi
 
 summary >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
`csgrep` reports `csdiff` as the tool that has generated the reports.  Even though it is technically true, it might be quite confusing to see it in the code scanning results instead of `ShellCheck`.