### PR TITLE
`ignored-codes` option is now deprecated :leaves: 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.5.1
+
+* `ignored-codes` option is now marked as deprecated and may be removed in future major release. Please consider using `.shellcheckrc` instead.
+
 ## v2.5.0
 
 * Add support for severity option, supported values are: `error`, `warning`, `info` and `style`

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Action currently accepts following options:
   with:
     base: <base-sha>
     head: <head-sha>
-    ignored-codes: <path to file with list of codes>
+    ignored-codes: <path to file with list of codes>    # <-- Deprecated option
     shell-scripts: <path to file with list of scripts>
     severity: <minimal severity level>
     token: <GitHub token>
@@ -144,6 +144,8 @@ Path to a text file which holds a list of ShellCheck codes which should be exclu
 
 * default value: `undefined`
 * requirements: `optional`
+
+> **Note**: _This option is now deprecated, please consider using `.shellcheckrc` instead._
 
 ### shell-scripts
 

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,7 @@ inputs:
     default: ${{ github.event.pull_request.head.sha }}
   ignored-codes:
     description: List of ShellCheck codes which should be excluded from validation
+    deprecationMessage: This option is now deprecated, please consider using `.shellcheckrc` instead.
     required: false
   shell-scripts:
     description: List of Shell scripts proposed for validation


### PR DESCRIPTION
Differential ShellCheck fully supports configuration via `.shellcheckrc`; there is no need for this option anymore.

Please consider using [`.shellcheckrc`](https://github.com/koalaman/shellcheck/blob/master/shellcheck.1.md#rc-files) since `ignored-codes` option may be removed in future major release.