### PR TITLE
Add option to enable `external-sources` and enable it by default :truck: 

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,7 +1,2 @@
 # Enable all optional checks.
 enable=all
-
-# Follow source statements even when the file is not specified as input.
-# By default, shellcheck will only follow files specified on the command line (plus /dev/null).
-# This option allows following any file the script may source.
-external-sources=true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.0.0
+
+* Add option `external-sources` and enable it by default
+
 ## v2.5.1
 
 * `ignored-codes` option is now marked as deprecated and may be removed in future major release. Please consider using `.shellcheckrc` instead.

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Path to a text file which holds a list of shell scripts which would not, otherwi
 
 ### external-sources
 
-Enable following of source statements even when the file is not specified as input. By default, [ShellCheck](https://github.com/koalaman/shellcheck/blob/master/shellcheck.1.md) will only follow files specified on the command line (plus `/dev/null`). This option allows following any file the script may source. This option may also be enabled using `external-sources=true` in `.shellcheckrc`.
+Enable following of source statements even when the file is not specified as input. By default, [ShellCheck](https://github.com/koalaman/shellcheck/blob/master/shellcheck.1.md) will only follow files specified on the command-line (plus `/dev/null`). This option allows following any file the script may source. This option may also be enabled using `external-sources=true` in `.shellcheckrc`.
 
 * default value: `true`
 * requirements: `optional`

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Action currently accepts following options:
     head: <head-sha>
     ignored-codes: <path to file with list of codes>    # <-- Deprecated option
     shell-scripts: <path to file with list of scripts>
+    external-sources: <true or false>
     severity: <minimal severity level>
     token: <GitHub token>
 
@@ -156,6 +157,13 @@ Path to a text file which holds a list of shell scripts which would not, otherwi
 * example: [.differential-shellcheck-scripts.txt](.github/.differential-shellcheck-scripts.txt)
 
 > **Note**: _Every path should be absolute and placed on a separate line. Avoid spaces in the list since they are interpreted as comments._
+
+### external-sources
+
+Enable following of source statements even when the file is not specified as input. By default, [ShellCheck](https://github.com/koalaman/shellcheck/blob/master/shellcheck.1.md) will only follow files specified on the command line (plus `/dev/null`). This option allows following any file the script may source. This option may also be enabled using `external-sources=true` in `.shellcheckrc`.
+
+* default value: `true`
+* requirements: `optional`
 
 ### severity
 

--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,7 @@ inputs:
     required: false
   external-sources:
     description: |
-      Enable following of source statements even when the file is not specified as input. By default, shellcheck will only follow files specified on the command line (plus /dev/null).
+      Enable following of source statements even when the file is not specified as input. By default, shellcheck will only follow files specified on the command-line (plus /dev/null).
       This option allows following any file the script may source. This option may also be enabled using external-sources=true in .shellcheckrc. This flag takes precedence.
     default: 'true'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,12 @@ inputs:
   shell-scripts:
     description: List of Shell scripts proposed for validation
     required: false
+  external-sources:
+    description: |
+      Enable following of source statements even when the file is not specified as input. By default, shellcheck will only follow files specified on the command line (plus /dev/null).
+      This option allows following any file the script may source. This option may also be enabled using external-sources=true in .shellcheckrc. This flag takes precedence.
+    default: 'true'
+    required: false
   severity:
     description: Specify minimum severity of errors to consider. Valid values in order of severity are error, warning, info and style. The default is style.
     default: style
@@ -41,3 +47,4 @@ runs:
   env:
     INPUT_IGNORED_CODES: ${{ inputs.ignored-codes }}
     INPUT_SHELL_SCRIPTS: ${{ inputs.shell-scripts }}
+    INPUT_EXTERNAL_SOURCES: ${{ inputs.external-sources }}

--- a/test/clean_array.bats
+++ b/test/clean_array.bats
@@ -9,7 +9,7 @@ setup () {
 }
 
 @test "clean_array() - arguments" {
-  source "$PROJECT_ROOT/src/functions.sh"
+  source "${PROJECT_ROOT}/src/functions.sh"
 
   local cleaned_array=()
   run clean_array
@@ -23,7 +23,7 @@ setup () {
 }
 
 @test "clean_array()" {
-  source "$PROJECT_ROOT/src/functions.sh"
+  source "${PROJECT_ROOT}/src/functions.sh"
 
   local cleaned_array=()
   local el1=$(echo -e "Something1 \n")

--- a/test/file_to_array.bats
+++ b/test/file_to_array.bats
@@ -9,7 +9,7 @@ setup () {
 }
 
 @test "file_to_array() - arguments" {
-  source "$PROJECT_ROOT/src/functions.sh"
+  source "${PROJECT_ROOT}/src/functions.sh"
 
   touch file.txt
 
@@ -21,7 +21,7 @@ setup () {
 
 # !FIXME
 # @test "file_to_array() - empty file" {
-#   source "$PROJECT_ROOT/src/functions.sh"
+#   source "${PROJECT_ROOT}/src/functions.sh"
 
 #   touch file.txt
 
@@ -32,7 +32,7 @@ setup () {
 # }
 
 @test "file_to_array() - in-line comments" {
-  source "$PROJECT_ROOT/src/functions.sh"
+  source "${PROJECT_ROOT}/src/functions.sh"
 
   echo -e "\
 # comment
@@ -49,7 +49,7 @@ Something3" > file.txt
 
 # !FIXME
 # @test "file_to_array() - no in-line comments" {
-#   source "$PROJECT_ROOT/src/functions.sh"
+#   source "${PROJECT_ROOT}/src/functions.sh"
 
 #   echo -e "\
 # # comment

--- a/test/has_shebang.bats
+++ b/test/has_shebang.bats
@@ -9,7 +9,7 @@ setup () {
 }
 
 @test "has_shebang() - #!/bin/{,a,ba,da,k}sh & #!/bin/bats" {
-  source "$PROJECT_ROOT/src/functions.sh"
+  source "${PROJECT_ROOT}/src/functions.sh"
 
   local interpreters=(
     '#!/bin/'{,a,ba,da,k}sh
@@ -25,7 +25,7 @@ setup () {
 }
 
 @test "has_shebang() - #!/usr/bin/{,a,ba,da,k}sh & #!/usr/bin/bats" {
-  source "$PROJECT_ROOT/src/functions.sh"
+  source "${PROJECT_ROOT}/src/functions.sh"
 
   local interpreters=(
     '#!/usr/bin/'{,a,ba,da,k}sh
@@ -41,7 +41,7 @@ setup () {
 }
 
 @test "has_shebang() - #!/usr/local/bin/{,a,ba,da,k}sh & #!/usr/local/bin/bats" {
-  source "$PROJECT_ROOT/src/functions.sh"
+  source "${PROJECT_ROOT}/src/functions.sh"
 
   local interpreters=(
     '#!/usr/local/bin/'{,a,ba,da,k}sh
@@ -57,7 +57,7 @@ setup () {
 }
 
 @test "has_shebang() - #!/bin/env {,a,ba,da,k}sh & #!/bin/env bats" {
-  source "$PROJECT_ROOT/src/functions.sh"
+  source "${PROJECT_ROOT}/src/functions.sh"
 
   local interpreters=(
     '#!/bin/env '{,a,ba,da,k}sh
@@ -73,7 +73,7 @@ setup () {
 }
 
 @test "has_shebang() - #!/usr/bin/env {,a,ba,da,k}sh & #!/usr/bin/env bats" {
-  source "$PROJECT_ROOT/src/functions.sh"
+  source "${PROJECT_ROOT}/src/functions.sh"
 
   local interpreters=(
     '#!/usr/bin/env '{,a,ba,da,k}sh
@@ -89,7 +89,7 @@ setup () {
 }
 
 @test "has_shebang() - #!/usr/local/bin/env {,a,ba,da,k}sh & #!/usr/local/bin/env bats" {
-  source "$PROJECT_ROOT/src/functions.sh"
+  source "${PROJECT_ROOT}/src/functions.sh"
 
   local interpreters=(
     '#!/usr/local/bin/env '{,a,ba,da,k}sh
@@ -106,7 +106,7 @@ setup () {
 
 # Source: https://stackoverflow.com/a/17409966
 @test "has_shebang() - SPACES" {
-  source "$PROJECT_ROOT/src/functions.sh"
+  source "${PROJECT_ROOT}/src/functions.sh"
 
   local space_bin=(
     ' # ! /bin/'{,a,ba,da,k}sh' '
@@ -167,7 +167,7 @@ setup () {
 }
 
 @test "has_shebang() - PARAMETERS" {
-  source "$PROJECT_ROOT/src/functions.sh"
+  source "${PROJECT_ROOT}/src/functions.sh"
 
   local interpreters=(
     '#!/bin/'{,a,ba,da,k}sh'  --something-something  -s something'
@@ -183,7 +183,7 @@ setup () {
 }
 
 @test "has_shebang() - FORGOTTEN OR SWITCHED" {
-  source "$PROJECT_ROOT/src/functions.sh"
+  source "${PROJECT_ROOT}/src/functions.sh"
 
   local templates=( {'!','#','#!','# !','!#','! #'}'/bin/sh' )
 
@@ -196,7 +196,7 @@ setup () {
 }
 
 @test "has_shebang() - TYPO" {
-  source "$PROJECT_ROOT/src/functions.sh"
+  source "${PROJECT_ROOT}/src/functions.sh"
 
   echo -e '#!/bin/bashees\n\nshell' > script
 
@@ -210,7 +210,7 @@ setup () {
 }
 
 @test "has_shebang() - INPUTS" {
-  source "$PROJECT_ROOT/src/functions.sh"
+  source "${PROJECT_ROOT}/src/functions.sh"
 
   run has_shebang
   assert_failure 1

--- a/test/is_debug.bats
+++ b/test/is_debug.bats
@@ -9,7 +9,7 @@ setup () {
 }
 
 @test "is_debug() - RUNNER_DEBUG=" {
-  source "$PROJECT_ROOT/src/functions.sh"
+  source "${PROJECT_ROOT}/src/functions.sh"
 
   RUNNER_DEBUG=
 
@@ -18,7 +18,7 @@ setup () {
 }
 
 @test "is_shell_extension() - RUNNER_DEBUG=1" {
-  source "$PROJECT_ROOT/src/functions.sh"
+  source "${PROJECT_ROOT}/src/functions.sh"
 
   RUNNER_DEBUG=1
 

--- a/test/is_false.bats
+++ b/test/is_false.bats
@@ -1,0 +1,39 @@
+setup_file () {
+  load 'test_helper/common-setup'
+  _common_setup
+}
+
+setup () {
+  load 'test_helper/bats-assert/load'
+  load 'test_helper/bats-support/load'
+}
+
+@test "is_false() - good values" {
+  source "$PROJECT_ROOT/src/functions.sh"
+
+  local v1="false"
+  local v2=0
+
+  run is_false "${v1}"
+  assert_success
+
+  run is_false "${v2}"
+  assert_success
+}
+
+@test "is_false() - bad values" {
+  source "$PROJECT_ROOT/src/functions.sh"
+
+  local v0=
+  local v1="true"
+  local v2=1
+
+  run is_false "${v0}"
+  assert_failure 1
+
+  run is_false "${v1}"
+  assert_failure 1
+
+  run is_false "${v2}"
+  assert_failure 1
+}

--- a/test/is_false.bats
+++ b/test/is_false.bats
@@ -9,7 +9,7 @@ setup () {
 }
 
 @test "is_false() - good values" {
-  source "$PROJECT_ROOT/src/functions.sh"
+  source "${PROJECT_ROOT}/src/functions.sh"
 
   local v1="false"
   local v2=0
@@ -22,7 +22,7 @@ setup () {
 }
 
 @test "is_false() - bad values" {
-  source "$PROJECT_ROOT/src/functions.sh"
+  source "${PROJECT_ROOT}/src/functions.sh"
 
   local v0=
   local v1="true"

--- a/test/is_script_listed.bats
+++ b/test/is_script_listed.bats
@@ -9,7 +9,7 @@ setup () {
 }
 
 @test "is_script_listed()" {
-  source "$PROJECT_ROOT/src/functions.sh"
+  source "${PROJECT_ROOT}/src/functions.sh"
 
   run is_script_listed "1.sh" "1.sh" "2.sh" "3.sh"
   assert_success

--- a/test/is_shell_extension.bats
+++ b/test/is_shell_extension.bats
@@ -9,7 +9,7 @@ setup () {
 }
 
 @test "is_shell_extension() - .sh" {
-  source "$PROJECT_ROOT/src/functions.sh"
+  source "${PROJECT_ROOT}/src/functions.sh"
 
   run is_shell_extension "1.sh"
   assert_success
@@ -22,7 +22,7 @@ setup () {
 }
 
 @test "is_shell_extension() - .ash" {
-  source "$PROJECT_ROOT/src/functions.sh"
+  source "${PROJECT_ROOT}/src/functions.sh"
 
   run is_shell_extension "1.ash"
   assert_success
@@ -35,7 +35,7 @@ setup () {
 }
 
 @test "is_shell_extension() - .bash" {
-  source "$PROJECT_ROOT/src/functions.sh"
+  source "${PROJECT_ROOT}/src/functions.sh"
 
   run is_shell_extension "1.bash"
   assert_success
@@ -48,7 +48,7 @@ setup () {
 }
 
 @test "is_shell_extension() - .dash" {
-  source "$PROJECT_ROOT/src/functions.sh"
+  source "${PROJECT_ROOT}/src/functions.sh"
 
   run is_shell_extension "1.dash"
   assert_success
@@ -61,7 +61,7 @@ setup () {
 }
 
 @test "is_shell_extension() - .ksh" {
-  source "$PROJECT_ROOT/src/functions.sh"
+  source "${PROJECT_ROOT}/src/functions.sh"
 
   run is_shell_extension "1.ksh"
   assert_success
@@ -74,7 +74,7 @@ setup () {
 }
 
 @test "is_shell_extension() - .bats" {
-  source "$PROJECT_ROOT/src/functions.sh"
+  source "${PROJECT_ROOT}/src/functions.sh"
 
   run is_shell_extension "1.bats"
   assert_success

--- a/test/is_true.bats
+++ b/test/is_true.bats
@@ -9,7 +9,7 @@ setup () {
 }
 
 @test "is_true() - good values" {
-  source "$PROJECT_ROOT/src/functions.sh"
+  source "${PROJECT_ROOT}/src/functions.sh"
 
   local v1="true"
   local v2=1
@@ -22,7 +22,7 @@ setup () {
 }
 
 @test "is_true() - bad values" {
-  source "$PROJECT_ROOT/src/functions.sh"
+  source "${PROJECT_ROOT}/src/functions.sh"
 
   local v0=
   local v1="false"

--- a/test/is_true.bats
+++ b/test/is_true.bats
@@ -1,0 +1,39 @@
+setup_file () {
+  load 'test_helper/common-setup'
+  _common_setup
+}
+
+setup () {
+  load 'test_helper/bats-assert/load'
+  load 'test_helper/bats-support/load'
+}
+
+@test "is_true() - good values" {
+  source "$PROJECT_ROOT/src/functions.sh"
+
+  local v1="true"
+  local v2=1
+
+  run is_true "${v1}"
+  assert_success
+
+  run is_true "${v2}"
+  assert_success
+}
+
+@test "is_true() - bad values" {
+  source "$PROJECT_ROOT/src/functions.sh"
+
+  local v0=
+  local v1="false"
+  local v2=0
+
+  run is_true "${v0}"
+  assert_failure 1
+
+  run is_true "${v1}"
+  assert_failure 1
+
+  run is_true "${v2}"
+  assert_failure 1
+}

--- a/test/join_by.bats
+++ b/test/join_by.bats
@@ -9,7 +9,7 @@ setup () {
 }
 
 @test "join_by() - ','" {
-  source "$PROJECT_ROOT/src/functions.sh"
+  source "${PROJECT_ROOT}/src/functions.sh"
 
   run join_by "," "1.sh" "2.sh" "3.sh"
   assert_output "1.sh,2.sh,3.sh"
@@ -22,7 +22,7 @@ setup () {
 }
 
 @test "join_by() - ' '" {
-  source "$PROJECT_ROOT/src/functions.sh"
+  source "${PROJECT_ROOT}/src/functions.sh"
 
   run join_by " " "1.sh" "2.sh" "3.sh"
   assert_output "1.sh 2.sh 3.sh"
@@ -35,7 +35,7 @@ setup () {
 }
 
 @test "join_by() - ''" {
-  source "$PROJECT_ROOT/src/functions.sh"
+  source "${PROJECT_ROOT}/src/functions.sh"
 
   run join_by "" "1.sh" "2.sh" "3.sh"
   assert_output "1.sh2.sh3.sh"


### PR DESCRIPTION
Adding option to enable sourcing of `external-sources` and enabling it by default as requested in:

- https://github.com/redhat-plumbers/dracut-rhel8/pull/18
- https://github.com/redhat-plumbers-in-action/differential-shellcheck/issues/89