### PR TITLE
doc: Improve support of GitHub themes :book: 

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,16 +90,20 @@ jobs:
 <details>
   <summary>Example of output in Changed files tab</summary>
   <p align="center">
-    <img src="doc/images/sarif-output-example-light.png#gh-light-mode-only" width="600" />
-    <img src="doc/images/sarif-output-example-dark.png#gh-dark-mode-only" width="600" />
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="doc/images/sarif-output-example-dark.png">
+      <img src="doc/images/sarif-output-example-light.png" width="600" />
+    </picture>
   </p>
 </details>
 
 <details>
   <summary>Example of @github-code-scanning bot review comment</summary>
   <p align="center">
-    <img src="doc/images/sarif-comment-light.png#gh-light-mode-only" width="600" />
-    <img src="doc/images/sarif-comment-dark.png#gh-dark-mode-only" width="600" />
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="doc/images/sarif-comment-dark.png">
+      <img src="doc/images/sarif-comment-light.png" width="600" />
+    </picture>
   </p>
 </details>
 


### PR DESCRIPTION
Update made based on a blog post: [Specify theme context for images in Markdown GA](https://github.blog/changelog/2022-08-15-specify-theme-context-for-images-in-markdown-ga/)

Attempting to fix an issue when on the GitHub marketplace are HTML attributes like `#gh-dark-mode-only` and `#gh-light-mode-only` ignored, resulting in displaying both images.

![Screenshot from 2022-08-29 12-42-26](https://user-images.githubusercontent.com/2879818/187183832-2d8753cf-50cd-4e27-94ed-803cea95c9f8.png)
