### PR TITLE
Autodetection: add support for `emacs` and `vi/vim` file types specifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v3.1.0
+
+* Autodetection: add support for `emacs` and `vi/vim` file types specifications
+  * `emacs` - `# -*- sh -*-`
+  * `vi`    - `# vi: (set)? (ft|filetype)=sh`
+  * `vim`   - `# vim: (set)? (ft|filetype)=sh`
+* Further improved autodetection of shell scripts based on shebangs and ShellCheck directives
+
 ## v3.0.0
 
 * Add option `external-sources` and enable it by default
@@ -16,7 +24,7 @@
 
 * Support for `ash`, `dash`, `ksh` and `bats` shell interpreters
 * Improve autodetection of shell scripts
-  * Support for detection based on shellcheck directive ; e.g. `# shellcheck shell=bash`
+  * Support for detection based on ShellCheck directive ; e.g. `# shellcheck shell=bash`
   * Support for generally used shebang prefixes like: `#!/usr/bin`, `#!/usr/local/bin`, `#!/bin/env␣`, `#!/usr/bin/env␣` and `#!/usr/local/bin/env␣` ; e.g. `#!/bin/env␣bash`
 
 ## v2.3.6

--- a/README.md
+++ b/README.md
@@ -35,9 +35,12 @@ To evaluate results, Differential ShellCheck uses utilities `csdiff` and `csgrep
 
 ## Features
 
-* Shell scripts auto-detection based on shebangs, shellcheck directives and file extensions
+* Shell scripts auto-detection based on shebangs, ShellCheck directives, file extensions and more
   * supported shell interpreters are: `sh`, `ash`, `bash`, `dash`, `ksh` and `bats`
   * supported shebangs are: `#!/bin/`, `#!/usr/bin/`, `#!/usr/local/bin/`, `#!/bin/env␣`, `#!/usr/bin/env␣` and `#!/usr/local/bin/env␣` ; e.g. `#!/bin/env␣bash`
+  * support for ShellCheck directives ; e.g. `# shellcheck shell=bash`
+  * support for [`emacs` modes specifications](https://www.gnu.org/software/emacs/manual/html_node/emacs/Choosing-Modes.html) ; e.g. `# -*- sh -*-`
+  * support for [`vi/vim` modeline specifications](http://vimdoc.sourceforge.net/htmldoc/options.html#modeline) ; e.g. `# vi: set filetype=sh`, `# vim: ft=sh`
 * Ability to allowlist specific error codes
 * Statistics about fixed and added errors
 * Colored console output with emojis

--- a/src/functions.sh
+++ b/src/functions.sh
@@ -34,18 +34,33 @@ is_shell_extension () {
 
 # Function to check whether the given file contains a shell shebang
 # - supported interpreters are {,a,ba,da,k}sh and bats including shellcheck directive
+# - also supports emacs and vi/vim file types specifications
 # https://unix.stackexchange.com/a/406939
+# emacs: https://www.gnu.org/software/emacs/manual/html_node/emacs/Choosing-Modes.html
+# vi/vim: http://vimdoc.sourceforge.net/htmldoc/options.html#modeline
 # $1 - <string> absolute path to a file
 # $? - return value - 0 on success
 has_shebang () {
-  [ $# -le 0 ] && return 1
+  [[ $# -le 0 ]] && return 1
   local file="$1"
 
+  # shell shebangs detection
   if head -n1 "${file}" | grep -E '^\s*((\#|\!)|(\#\s*\!)|(\!\s*\#))\s*(\/usr(\/local)?)?\/bin\/(env\s+)?(sh|ash|bash|dash|ksh|bats)\b'; then
     return 0
   fi
 
-  if grep -E '\s*\#\s*shellcheck\s+shell=(sh|ash|bash|dash|ksh|bats)\s*' "${file}"; then
+  # ShellCheck shell directive detection
+  if grep -E '^\s*\#\s*shellcheck\s+shell=(sh|ash|bash|dash|ksh|bats)\s*' "${file}"; then
+    return 0
+  fi
+
+  # Emacs mode detection
+  if grep -E '^\s*\#\s+-\*-\s+(sh|ash|bash|dash|ksh|bats)\s+-\*-\s*' "${file}"; then
+    return 0
+  fi
+
+  # Vi and Vim modeline filetype detection
+  if grep -E '^\s*\#\s+vim?:\s+(set\s+)?(ft|filetype)=(sh|ash|bash|dash|ksh|bats)\s*' "${file}"; then
     return 0
   fi
 

--- a/test/has_shebang.bats
+++ b/test/has_shebang.bats
@@ -18,7 +18,7 @@ setup () {
 
   for i in "${interpreters[@]}"; do
     echo -e "$i\n\nshell" > script
-    
+
     run has_shebang "script"
     assert_success
   done
@@ -34,7 +34,7 @@ setup () {
 
   for i in "${interpreters[@]}"; do
     echo -e "$i\n\nshell" > script
-    
+
     run has_shebang "script"
     assert_success
   done
@@ -50,7 +50,7 @@ setup () {
 
   for i in "${interpreters[@]}"; do
     echo -e "$i\n\nshell" > script
-    
+
     run has_shebang "script"
     assert_success
   done
@@ -66,7 +66,7 @@ setup () {
 
   for i in "${interpreters[@]}"; do
     echo -e "$i\n\nshell" > script
-    
+
     run has_shebang "script"
     assert_success
   done
@@ -82,7 +82,7 @@ setup () {
 
   for i in "${interpreters[@]}"; do
     echo -e "$i\n\nshell" > script
-    
+
     run has_shebang "script"
     assert_success
   done
@@ -98,7 +98,7 @@ setup () {
 
   for i in "${interpreters[@]}"; do
     echo -e "$i\n\nshell" > script
-    
+
     run has_shebang "script"
     assert_success
   done
@@ -135,32 +135,32 @@ setup () {
 
   for i in "${!space_bin[@]}"; do
     echo -e "${space_bin[i]}\n\nshell" > script
-    
+
     run has_shebang "script"
     assert_success
 
     echo -e "${space_usr_bin[i]}\n\nshell" > script
-    
+
     run has_shebang "script"
     assert_success
 
     echo -e "${space_usr_local_bin[i]}\n\nshell" > script
-    
+
     run has_shebang "script"
     assert_success
 
     echo -e "${space_bin_env[i]}\n\nshell" > script
-    
+
     run has_shebang "script"
     assert_success
 
     echo -e "${space_usr_bin_env[i]}\n\nshell" > script
-    
+
     run has_shebang "script"
     assert_success
 
     echo -e "${space_usr_local_bin_env[i]}\n\nshell" > script
-    
+
     run has_shebang "script"
     assert_success
   done
@@ -176,7 +176,7 @@ setup () {
 
   for i in "${interpreters[@]}"; do
     echo -e "$i\n\nshell" > script
-    
+
     run has_shebang "script"
     assert_success
   done
@@ -189,7 +189,7 @@ setup () {
 
   for i in "${templates[@]}"; do
     echo -e "$i\n\nshell" > script
-    
+
     run has_shebang "script"
     assert_success
   done
@@ -238,6 +238,94 @@ setup () {
   touch empty.txt
   run has_shebang "empty.txt"
   assert_failure 2
+}
+
+@test "has_shebang() - emacs file types specification" {
+  source "${PROJECT_ROOT}/src/functions.sh"
+
+  local emacs=(
+    '# -*- sh -*-'
+    '   # -*- sh -*-'
+    '   # -*-  sh  -*-'
+    ' #  -*-  sh  -*- ... ...'
+  )
+  local emacs_incorrect=(
+    ' -*- sh -*-'
+    '# -*-  -*-'
+    '# -*- sh -*'
+    '# - * - sh - * - '
+  )
+
+  for i in "${!emacs[@]}"; do
+    echo -e "${emacs[i]}\n\nshell" > script
+
+    run has_shebang "script"
+    assert_success
+
+    echo -e "${emacs_incorrect[i]}\n\nshell" > script
+
+    run has_shebang "script"
+    assert_failure 2
+  done
+}
+
+@test "has_shebang() - vi/vim file types specification" {
+  source "${PROJECT_ROOT}/src/functions.sh"
+
+  local vi=(
+    '# vi: ft=sh'
+    ' # vi:  ft=sh ... ...'
+    '# vi: filetype=sh'
+    ' # vi:  filetype=sh ... ...'
+    '# vi: set filetype=sh'
+    ' # vi:  set filetype=sh ... ...'
+  )
+  local vim=(
+    '# vim: ft=sh'
+    ' # vim:  ft=sh ... ...'
+    '# vim: filetype=sh'
+    ' # vim:  filetype=sh ... ...'
+    '# vim: set filetype=sh'
+    ' # vim:  set filetype=sh ... ...'
+  )
+  local vi_incorrect=(
+    ' # vi : ft=sh'
+    ' # vi:  ft = sh'
+    ' # vi : filetype=sh'
+    ' # vi:  filetype = sh'
+    ' # vi : set filetype=sh'
+    ' # vi:  set filetype = shell'
+  )
+  local vim_incorrect=(
+    ' # vim : ft=sh'
+    ' # vim:  ft = sh'
+    ' # vim : filetype=sh'
+    ' # vim:  filetype = sh'
+    ' # vim : set filetype=sh'
+    ' # vim:  set filetype = shell'
+  )
+
+  for i in "${!vi[@]}"; do
+    echo -e "${vi[i]}\n\nshell" > script
+
+    run has_shebang "script"
+    assert_success
+
+    echo -e "${vi_incorrect[i]}\n\nshell" > script
+
+    run has_shebang "script"
+    assert_failure 2
+
+    echo -e "${vim[i]}\n\nshell" > script
+
+    run has_shebang "script"
+    assert_success
+
+    echo -e "${vim_incorrect[i]}\n\nshell" > script
+
+    run has_shebang "script"
+    assert_failure 2
+  done
 }
 
 teardown () {


### PR DESCRIPTION
Supported is:
* `emacs` - `# -*- sh -*-`
* `vi`    - `# vi: (set)? (ft|filetype)=sh`
* `vim`   - `# vim: (set)? (ft|filetype)=sh`

---

- [x] Implementation
- [x] Tests
- [x] Documentation
- [x] Changelog