### PR TITLE
Further improve autodetection of shell scripts

### DIFF
--- a/src/functions.sh
+++ b/src/functions.sh
@@ -41,30 +41,15 @@ has_shebang () {
   [ $# -le 0 ] && return 1
   local file="$1"
 
-  if IFS= read -r line < "./${file}" ; then
-    local shebang_regexp="^\s*((\#|\!)|(\#\s*\!)|(\!\s*\#))\s*(\/usr(\/local)?)?\/bin\/(env\s+)?interpreter\b"
-    local shellcheck_regexp="\s*\#\s*shellcheck\s+shell=interpreter\s*"
-
-    # shell shebangs detection
-    [[ $line =~ ${shebang_regexp//interpreter/sh} ]] && return 0
-    [[ $line =~ ${shebang_regexp//interpreter/ash} ]] && return 0
-    [[ $line =~ ${shebang_regexp//interpreter/bash} ]] && return 0
-    [[ $line =~ ${shebang_regexp//interpreter/dash} ]] && return 0
-    [[ $line =~ ${shebang_regexp//interpreter/ksh} ]] && return 0
-    [[ $line =~ ${shebang_regexp//interpreter/bats} ]] && return 0
-
-    # ShellCheck shell detection
-    [[ $line =~ ${shellcheck_regexp//interpreter/sh} ]] && return 0
-    [[ $line =~ ${shellcheck_regexp//interpreter/ash} ]] && return 0
-    [[ $line =~ ${shellcheck_regexp//interpreter/bash} ]] && return 0
-    [[ $line =~ ${shellcheck_regexp//interpreter/dash} ]] && return 0
-    [[ $line =~ ${shellcheck_regexp//interpreter/ksh} ]] && return 0
-    [[ $line =~ ${shellcheck_regexp//interpreter/bats} ]] && return 0
-
-    return 2
+  if head -n1 "${file}" | grep -E '^\s*((\#|\!)|(\#\s*\!)|(\!\s*\#))\s*(\/usr(\/local)?)?\/bin\/(env\s+)?(sh|ash|bash|dash|ksh|bats)\b'; then
+    return 0
   fi
 
-  return 3
+  if grep -E '\s*\#\s*shellcheck\s+shell=(sh|ash|bash|dash|ksh|bats)\s*' "${file}"; then
+    return 0
+  fi
+
+  return 2
 }
 
 # Function to concatenate an array of strings where the first argument

--- a/test/has_shebang.bats
+++ b/test/has_shebang.bats
@@ -204,7 +204,7 @@ setup () {
   )
 
   for i in "${interpreters[@]}"; do
-    echo -e "#!/bin/mywrapper\n# shellcheck shell=$i\n\nshell" > script
+    echo -e "#!/bin/mywrapper\n# shellcheck shell=${i}\n\nshell" > script
     
     run has_shebang "script"
     assert_success

--- a/test/has_shebang.bats
+++ b/test/has_shebang.bats
@@ -195,6 +195,22 @@ setup () {
   done
 }
 
+@test "has_shebang() - SHELL DIRECTIVE" {
+  source "${PROJECT_ROOT}/src/functions.sh"
+
+  local interpreters=(
+    {,a,ba,da,k}sh
+    'bats'
+  )
+
+  for i in "${interpreters[@]}"; do
+    echo -e "#!/bin/$i\n# shellcheck shell=$i\n\nshell" > script
+    
+    run has_shebang "script"
+    assert_success
+  done
+}
+
 @test "has_shebang() - TYPO" {
   source "${PROJECT_ROOT}/src/functions.sh"
 

--- a/test/has_shebang.bats
+++ b/test/has_shebang.bats
@@ -204,7 +204,7 @@ setup () {
   )
 
   for i in "${interpreters[@]}"; do
-    echo -e "#!/bin/$i\n# shellcheck shell=$i\n\nshell" > script
+    echo -e "#!/bin/mywrapper\n# shellcheck shell=$i\n\nshell" > script
     
     run has_shebang "script"
     assert_success

--- a/test/has_shebang.bats
+++ b/test/has_shebang.bats
@@ -221,7 +221,7 @@ setup () {
 
   touch empty.txt
   run has_shebang "empty.txt"
-  assert_failure 3
+  assert_failure 2
 }
 
 teardown () {


### PR DESCRIPTION
Follow up to #73 from @jamacku

The original `while` loop will only ever read the first line of the file (which is fine for detecting a shebang), but it's supposed to also account for a `# shellcheck shell=something` directive ([SC1008](https://www.shellcheck.net/wiki/SC1008)), but that directive isn't allowed on the first line.

Additionally;
```shell
#!/bin/mywrapper
# there can be any number of comments between the shebang and the shellcheck shell directive
# and it's still valid
# as long as the file starts with a shebang
# and there's nothing except (any number of) comment lines between the shebang and the shellcheck shell directive
# shellcheck shell=bash
echo "Hello World"
```

These changes don't check if the directive is in the right place in the file, just if it exists. The file will be added to the list to be checked, and shellcheck will provide the warning or error about the directive if it's not in the correct place.