### PR TITLE
Set strict permissions for GitHub Workflows :lock: 

### DIFF
--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -13,7 +13,6 @@ env:
   REGISTRY: ghcr.io
 
 permissions:
-  packages: write
   contents: read
 
 jobs:

--- a/.github/workflows/differential-shellcheck.yml
+++ b/.github/workflows/differential-shellcheck.yml
@@ -13,10 +13,6 @@ jobs:
     name: Test latest changes
     runs-on: ubuntu-latest
 
-    permissions:
-      security-events: write
-      pull-requests: write
-
     steps:
       - name: Repository checkout
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -12,9 +12,6 @@ jobs:
   label-component:
     runs-on: ubuntu-latest
 
-    permissions:
-      issues: write
-
     strategy:
       matrix:
         template: [ issue-template.yml ]

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -13,9 +13,6 @@ jobs:
   actions-tagger:
     runs-on: ubuntu-latest
 
-    permissions:
-      contents: write
-
     steps:
       - name: Repository checkout
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -14,10 +14,6 @@ jobs:
     name: Update release Draft
     runs-on: ubuntu-latest
 
-    permissions:
-      contents: write
-      pull-requests: write
-
     steps:
       - uses: release-drafter/release-drafter@6df64e4ba4842c203c604c1f45246c5863410adb
         env:

--- a/.github/workflows/scorecard-analysis.yml
+++ b/.github/workflows/scorecard-analysis.yml
@@ -18,13 +18,6 @@ jobs:
   analysis:
     name: Scorecards analysis
     runs-on: ubuntu-latest
-    permissions:
-      # Needed to upload the results to code-scanning dashboard.
-      security-events: write
-      # Used to receive a badge. (Upcoming feature)
-      id-token: write
-      actions: read
-      contents: read
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Removed permissions should not be required since this isn't a private repository.