### PR TITLE
Support full ShellCheck scans :detective: 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "test/test_helper/bats-assert"]
 	path = test/test_helper/bats-assert
 	url = https://github.com/bats-core/bats-assert.git
+[submodule "test/test_helper/bats-file"]
+	path = test/test_helper/bats-file
+	url = https://github.com/bats-core/bats-file.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,6 @@ RUN dnf -y install "./${rpm_shellcheck}" "./${rpm_csdiff}" \
 RUN mkdir -p /action
 WORKDIR /action
 
-COPY src/index.sh src/functions.sh ./
+COPY src/* ./
 
 ENTRYPOINT ["/action/index.sh"]

--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ To evaluate results, Differential ShellCheck uses utilities `csdiff` and `csgrep
 * Ability to run in a verbose mode when run with [debug option](https://github.blog/changelog/2022-05-24-github-actions-re-run-jobs-with-debug-logging/)
 * Results displayed as [job summaries](https://github.blog/2022-05-09-supercharging-github-actions-with-job-summaries/)
 * Ability to configure Differential ShellCheck using [`.shellcheckrc`](https://github.com/koalaman/shellcheck/blob/master/shellcheck.1.md#rc-files)
-* Support for GitHub `push` triggering event
 
 ## Usage
 
@@ -147,6 +146,8 @@ Action currently accepts following options:
     pull-request-head: <sha1>
     push-event-base: <sha1>
     push-event-head: <sha1>
+    diff-scan: <true or false>
+    strict-check-on-push: <true or false>
     ignored-codes: <path to file with list of codes>    # <-- Deprecated option
     shell-scripts: <path to file with list of scripts>
     external-sources: <true or false>
@@ -203,6 +204,28 @@ The name of the event that triggered the workflow run. Supported values are: `pu
 `SHA1` of the last commit after push. Input is used when `triggering-event` is set to `push`.
 
 * default value: `${{ github.event.after }}`
+* requirements: `optional`
+
+### diff-scan
+
+Input allows requesting a specific type of scan. Input is considered only if `triggering-event` is set to `manual`.
+
+Default types of scans based on `triggering-event` input:
+
+| `triggering-event` | type of scan               |
+|--------------------|----------------------------|
+| `pull_request`     | differential               |
+| `push`             | full                       |
+| `manual`           | based on `diff-scan` input |
+
+* default value: `true`
+* requirements: `optional`
+
+### strict-check-on-push
+
+Differential ShellCheck performs full scans when running on a `push` event, but the Action fails only when new defects are added. This option allows overwriting this behavior. Hence when `strict-check-on-push` is set to `true` it will fail when any defect is discovered.
+
+* default value: `false`
 * requirements: `optional`
 
 ### ignored-codes

--- a/action.yml
+++ b/action.yml
@@ -41,6 +41,17 @@ inputs:
     required: false
     default: ${{ github.event.after }}
 
+  diff-scan:
+    description: Input allowing to request specific type of scan. Input is taken into consideration only if `triggering-event` is set to `manual`.
+    required: false
+    default: 'true'
+  strict-check-on-push:
+    description: |
+      Differential ShellCheck performs full scans when running on a `push` event, but the Action fails only when new defects are added.
+      This option allows overwriting this behavior. Hence when `strict-check-on-push` is set to `true` it will fail when any defect is discovered.
+    required: false
+    default: 'false'
+
   ignored-codes:
     description: List of ShellCheck codes which should be excluded from validation.
     deprecationMessage: This option is now deprecated, please consider using `.shellcheckrc` instead.
@@ -63,10 +74,6 @@ inputs:
     description: GitHub TOKEN used to upload SARIF data.
     required: false
 
-outputs:
-  result:
-    description: Result of Differential ShellCheck.
-
 runs:
   using: docker
   image: docker://ghcr.io/redhat-plumbers-in-action/differential-shellcheck:v3.3.1
@@ -76,6 +83,8 @@ runs:
     INPUT_PULL_REQUEST_HEAD: ${{ inputs.pull-request-head }}
     INPUT_PUSH_EVENT_BASE: ${{ inputs.push-event-base }}
     INPUT_PUSH_EVENT_HEAD: ${{ inputs.push-event-head }}
+    INPUT_DIFF_SCAN: ${{ inputs.diff-scan }}
+    INPUT_STRICT_CHECK_ON_PUSH: ${{ inputs.strict-check-on-push }}
     INPUT_IGNORED_CODES: ${{ inputs.ignored-codes }}
     INPUT_SHELL_SCRIPTS: ${{ inputs.shell-scripts }}
     INPUT_EXTERNAL_SOURCES: ${{ inputs.external-sources }}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,7 +23,13 @@
             token: ${{ secrets.GITHUB_TOKEN }}
   ```
 
-  > **Note**: When using `--force` action doesn't work properly when triggered on `push` events.
+  > **Note**: When using `--force` action doesn't work properly when triggered on `push` events
+
+* Action now perform full scans on `push` event by default and on `manual` trigger when requested
+* Addition of new Summary page for full scans
+* Removal of unused output - `ENV.LIST_OF_SCRIPTS`
+* Increased code coverage
+* Some minor bugfixes, ShellCheck fixes, and CI updates
 
 ## v3.3.0
 

--- a/src/summary.sh
+++ b/src/summary.sh
@@ -1,0 +1,120 @@
+# shellcheck shell=bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Print scanning summary
+summary () {
+  scan_summary=""
+  if [[ ${FULL_SCAN} -eq 0 ]] && is_strict_check_on_push_demanded; then
+    scan_summary=$(full_scan_summary)
+  else
+    scan_summary=$(diff_scan_summary)
+  fi
+
+  local useful_links=
+  useful_links=$(summary_useful_links)
+  
+  echo -e "\
+### Differential ShellCheck 🐚
+
+${scan_summary}
+
+${useful_links}"
+}
+
+# Handle scanning summary for standard (full) scans
+full_scan_summary () {
+  local results_link
+  results_link=$(compose_results_link "Defects")
+
+  local added_issues
+  added_issues=$(get_number_of defects)
+
+  echo -e "\
+Number of scripts: \`${#all_scripts[@]}\`
+
+${results_link}: **${added_issues:-0}**"
+}
+
+# Handle scanning summary for differential scans
+diff_scan_summary () {
+  local results_link
+  results_link=$(compose_results_link "Errors / Warnings / Notes")
+
+  local fixed_issues
+  fixed_issues=$(get_number_of fixes)
+
+  local added_issues
+  added_issues=$(get_number_of defects)
+
+  echo -e "\
+Changed scripts: \`${#only_changed_scripts[@]}\`
+
+|                    | ❌ Added                 | ✅ Fixed                 |
+|:------------------:|:------------------------:|:------------------------:|
+| ⚠️ ${results_link} |  **${added_issues:-0}**  |  **${fixed_issues:-0}**  |"
+}
+
+# Get number of fixed issues or added defects
+# $1 - <fixes | defects> a name of statistics
+# $? - return value - 0 on success
+get_number_of () {
+  [[ $# -le 0 ]] && return 1
+
+  grep -Eo "[0-9]*" < <(csgrep --mode=stat ../"${1}".log)
+}
+
+# Create full Markdown style link to results
+# When no link is available it returns regular text
+# Link is printed on std output
+# $? - return value - 0 on success
+compose_results_link () {
+  [[ ${#1} -le 0 ]] && return 1
+
+  local results_link_title="${1}"
+  local link=""
+  link=$(link_to_results)
+  results_link=""
+
+  [[ -z "${link}" ]] && results_link="${results_link_title}"
+  [[ -n "${link}" ]] && results_link="[${results_link_title}](${link})"
+
+  echo -e "${results_link}"
+}
+
+# Get links to results based on triggering event
+# Link is printed on std output
+# $? - return value - 0 on success
+link_to_results () {
+  local pull_number=${GITHUB_REF##refs\/pull\/}
+  pull_number=${pull_number%%\/merge}
+
+  # !FIXME: Currently variable `tool` doesn't exist ...
+  local push_link="https://github.com/${GITHUB_REPOSITORY}/security/code-scanning?query=tool%3A${SCANNING_TOOL:-"shellcheck"}+branch%3A${GITHUB_REF_NAME:-"main"}+is%3Aopen"
+  local pull_request_link="https://github.com/${GITHUB_REPOSITORY}/security/code-scanning?query=pr%3A${pull_number}+tool%3A${SCANNING_TOOL:-"shellcheck"}+is%3Aopen"
+
+  case ${INPUT_TRIGGERING_EVENT:-${GITHUB_EVENT_NAME}} in
+    "push")
+      echo -e "${push_link}"
+      ;;
+
+    "pull_request")
+      echo -e "${pull_request_link}"
+      ;;
+
+    *)
+      echo -e ""
+  esac 
+}
+
+# Print useful information at the end of summary report
+# $? - return value - 0 on success
+summary_useful_links () {
+  echo -e "\
+#### Useful links
+
+- [Differential ShellCheck Documentation](https://github.com/redhat-plumbers-in-action/differential-shellcheck#readme)
+- [ShellCheck Documentation](https://github.com/koalaman/shellcheck#readme)
+
+---
+_ℹ️ If you have an issue with this GitHub action, please try to run it in the [debug mode](https://github.blog/changelog/2022-05-24-github-actions-re-run-jobs-with-debug-logging/) and submit an [issue](https://github.com/redhat-plumbers-in-action/differential-shellcheck/issues/new)._"
+}

--- a/src/validation.sh
+++ b/src/validation.sh
@@ -1,0 +1,33 @@
+# shellcheck shell=bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+get_fixes () {
+  [[ $# -le 1 ]] && return 1
+
+  csdiff --fixed "${1}" "${2}" > ../fixes.log
+}
+
+evaluate_and_print_fixes () {
+  if [[ -s ../fixes.log ]]; then
+    echo -e "✅ ${GREEN}Fixed defects${NOCOLOR}"
+    csgrep ../fixes.log
+  else
+    echo -e "ℹ️ ${YELLOW}No Fixes!${NOCOLOR}"
+  fi
+}
+
+get_defects () {
+  [[ $# -le 1 ]] && return 1
+
+  csdiff --fixed "${1}" "${2}" > ../defects.log
+}
+
+evaluate_and_print_defects () {
+  if [[ -s ../defects.log ]]; then
+    echo -e "✋ ${YELLOW}Defects, NEEDS INSPECTION${NOCOLOR}"
+    csgrep ../defects.log
+    return 1
+  fi
+
+  echo -e "🥳 ${GREEN}No defects added. Yay!${NOCOLOR}"
+}

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -17,7 +17,7 @@ ARG rpm_shellcheck="ShellCheck-${version_shellcheck}.fc${fedora}.${arch}.rpm"
 # --- Install dependencies --- #
 
 RUN dnf -y upgrade
-RUN dnf -y install git koji kcov bats \
+RUN dnf -y install git koji kcov bats diffutils \
     && dnf clean all
 
 # Download rpms from koji

--- a/test/compose_results_link.bats
+++ b/test/compose_results_link.bats
@@ -10,7 +10,7 @@ setup () {
   load 'test_helper/bats-support/load'
 }
 
-@test "link_to_results() - trigger event = push" {
+@test "compose_results_link() - trigger event = push" {
   source "${PROJECT_ROOT}/src/summary.sh"
 
   INPUT_TRIGGERING_EVENT="push"
@@ -19,12 +19,15 @@ setup () {
   SCANNING_TOOL="not-shellcheck"
   GITHUB_REF="refs/heads/${GITHUB_REF_NAME}"
 
-  run link_to_results
+  run compose_results_link "Result Link"
   assert_success
-  assert_output "https://github.com/${GITHUB_REPOSITORY}/security/code-scanning?query=tool%3A${SCANNING_TOOL}+branch%3A${GITHUB_REF_NAME}+is%3Aopen"
+  assert_output "[Result Link](https://github.com/${GITHUB_REPOSITORY}/security/code-scanning?query=tool%3A${SCANNING_TOOL}+branch%3A${GITHUB_REF_NAME}+is%3Aopen)"
+
+  run compose_results_link
+  assert_failure 1
 }
 
-@test "link_to_results() - trigger event = pull_request" {
+@test "compose_results_link() - trigger event = pull_request" {
   source "${PROJECT_ROOT}/src/summary.sh"
 
   INPUT_TRIGGERING_EVENT="pull_request"
@@ -33,20 +36,26 @@ setup () {
   SCANNING_TOOL="not-shellcheck"
   GITHUB_REF="refs/pull/${PR_NUMBER}/merge"
 
-  run link_to_results
+  run compose_results_link "Result Link"
   assert_success
-  assert_output "https://github.com/${GITHUB_REPOSITORY}/security/code-scanning?query=pr%3A${PR_NUMBER}+tool%3A${SCANNING_TOOL}+is%3Aopen"
+  assert_output "[Result Link](https://github.com/${GITHUB_REPOSITORY}/security/code-scanning?query=pr%3A${PR_NUMBER}+tool%3A${SCANNING_TOOL}+is%3Aopen)"
+
+  run compose_results_link
+  assert_failure 1
 }
 
-@test "link_to_results() - trigger event = manual" {
+@test "compose_results_link() - trigger event = manual" {
   source "${PROJECT_ROOT}/src/summary.sh"
 
   INPUT_TRIGGERING_EVENT="manual"
   SCANNING_TOOL="not-shellcheck"
 
-  run link_to_results
+  run compose_results_link "Result Link"
   assert_success
-  assert_output ""
+  assert_output "Result Link"
+
+  run compose_results_link
+  assert_failure 1
 }
 
 teardown () {

--- a/test/evaluate_and_print_defects.bats
+++ b/test/evaluate_and_print_defects.bats
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+setup_file () {
+  load 'test_helper/common-setup'
+  _common_setup
+}
+
+setup () {
+  load 'test_helper/bats-assert/load'
+  load 'test_helper/bats-support/load'
+}
+
+@test "evaluate_and_print_defects() - some defects" {
+  source "${PROJECT_ROOT}/src/validation.sh"
+
+  cp ./test/fixtures/evaluate_and_print_defects/defects.log ../defects.log
+
+  run evaluate_and_print_defects
+  assert_failure 1
+  assert_output "\
+✋ Defects, NEEDS INSPECTION
+Error: SHELLCHECK_WARNING:
+src/index.sh:53:10: warning[SC2154]: MAIN_HEADING is referenced but not assigned.
+
+Error: SHELLCHECK_WARNING:
+src/index.sh:56:14: warning[SC2154]: WHITE is referenced but not assigned.
+
+Error: SHELLCHECK_WARNING:
+src/index.sh:56:56: warning[SC2154]: NOCOLOR is referenced but not assigned."
+}
+
+@test "evaluate_and_print_defects() - no defects" {
+  source "${PROJECT_ROOT}/src/validation.sh"
+
+  run evaluate_and_print_defects
+  assert_success
+  assert_output "🥳 No defects added. Yay!"
+}
+
+teardown () {
+  rm -f ../defects.log
+}

--- a/test/evaluate_and_print_fixes.bats
+++ b/test/evaluate_and_print_fixes.bats
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+setup_file () {
+  load 'test_helper/common-setup'
+  _common_setup
+}
+
+setup () {
+  load 'test_helper/bats-assert/load'
+  load 'test_helper/bats-support/load'
+}
+
+@test "evaluate_and_print_fixes() - some fixes" {
+  source "${PROJECT_ROOT}/src/validation.sh"
+
+  cp ./test/fixtures/evaluate_and_print_fixes/fixes.log ../fixes.log
+
+  run evaluate_and_print_fixes
+  assert_success
+  assert_output "\
+✅ Fixed defects
+Error: SHELLCHECK_WARNING:
+src/index.sh:7:3: note[SC1091]: Not following: functions.sh: openBinaryFile: does not exist (No such file or directory)"
+}
+
+@test "evaluate_and_print_fixes() - no fixes" {
+  source "${PROJECT_ROOT}/src/validation.sh"
+
+  run evaluate_and_print_fixes
+  assert_success
+  assert_output "ℹ️ No Fixes!"
+}
+
+teardown () {
+  rm -f ../fixes.log
+}

--- a/test/fixtures/evaluate_and_print_defects/defects.log
+++ b/test/fixtures/evaluate_and_print_defects/defects.log
@@ -1,0 +1,8 @@
+Error: SHELLCHECK_WARNING:
+src/index.sh:53:10: warning[SC2154]: MAIN_HEADING is referenced but not assigned.
+
+Error: SHELLCHECK_WARNING:
+src/index.sh:56:14: warning[SC2154]: WHITE is referenced but not assigned.
+
+Error: SHELLCHECK_WARNING:
+src/index.sh:56:56: warning[SC2154]: NOCOLOR is referenced but not assigned.

--- a/test/fixtures/evaluate_and_print_fixes/fixes.log
+++ b/test/fixtures/evaluate_and_print_fixes/fixes.log
@@ -1,0 +1,2 @@
+Error: SHELLCHECK_WARNING:
+src/index.sh:7:3: note[SC1091]: Not following: functions.sh: openBinaryFile: does not exist (No such file or directory)

--- a/test/fixtures/get_defects/base.err
+++ b/test/fixtures/get_defects/base.err
@@ -1,0 +1,4 @@
+src/index.sh:7:3: note: Not following: functions.sh: openBinaryFile: does not exist (No such file or directory) [SC1091]
+src/index.sh:39:42: warning: BASE is referenced but not assigned. [SC2154]
+src/index.sh:39:53: warning: HEAD is referenced but not assigned. [SC2154]
+src/index.sh:50:10: warning: VERSIONS_HEADING is referenced but not assigned. [SC2154]

--- a/test/fixtures/get_defects/defects.log
+++ b/test/fixtures/get_defects/defects.log
@@ -1,0 +1,8 @@
+Error: SHELLCHECK_WARNING:
+src/index.sh:53:10: warning[SC2154]: MAIN_HEADING is referenced but not assigned.
+
+Error: SHELLCHECK_WARNING:
+src/index.sh:56:14: warning[SC2154]: WHITE is referenced but not assigned.
+
+Error: SHELLCHECK_WARNING:
+src/index.sh:56:56: warning[SC2154]: NOCOLOR is referenced but not assigned.

--- a/test/fixtures/get_defects/head.err
+++ b/test/fixtures/get_defects/head.err
@@ -1,0 +1,6 @@
+src/index.sh:39:42: warning: BASE is referenced but not assigned. [SC2154]
+src/index.sh:39:53: warning: HEAD is referenced but not assigned. [SC2154]
+src/index.sh:50:10: warning: VERSIONS_HEADING is referenced but not assigned. [SC2154]
+src/index.sh:53:10: warning: MAIN_HEADING is referenced but not assigned. [SC2154]
+src/index.sh:56:14: warning: WHITE is referenced but not assigned. [SC2154]
+src/index.sh:56:56: warning: NOCOLOR is referenced but not assigned. [SC2154]

--- a/test/fixtures/get_fixes/base.err
+++ b/test/fixtures/get_fixes/base.err
@@ -1,0 +1,7 @@
+src/index.sh:7:3: note: Not following: functions.sh: openBinaryFile: does not exist (No such file or directory) [SC1091]
+src/index.sh:39:42: warning: BASE is referenced but not assigned. [SC2154]
+src/index.sh:39:53: warning: HEAD is referenced but not assigned. [SC2154]
+src/index.sh:50:10: warning: VERSIONS_HEADING is referenced but not assigned. [SC2154]
+src/index.sh:53:10: warning: MAIN_HEADING is referenced but not assigned. [SC2154]
+src/index.sh:56:14: warning: WHITE is referenced but not assigned. [SC2154]
+src/index.sh:56:56: warning: NOCOLOR is referenced but not assigned. [SC2154]

--- a/test/fixtures/get_fixes/fixes.log
+++ b/test/fixtures/get_fixes/fixes.log
@@ -1,0 +1,2 @@
+Error: SHELLCHECK_WARNING:
+src/index.sh:7:3: note[SC1091]: Not following: functions.sh: openBinaryFile: does not exist (No such file or directory)

--- a/test/fixtures/get_fixes/head.err
+++ b/test/fixtures/get_fixes/head.err
@@ -1,0 +1,6 @@
+src/index.sh:39:42: warning: BASE is referenced but not assigned. [SC2154]
+src/index.sh:39:53: warning: HEAD is referenced but not assigned. [SC2154]
+src/index.sh:50:10: warning: VERSIONS_HEADING is referenced but not assigned. [SC2154]
+src/index.sh:53:10: warning: MAIN_HEADING is referenced but not assigned. [SC2154]
+src/index.sh:56:14: warning: WHITE is referenced but not assigned. [SC2154]
+src/index.sh:56:56: warning: NOCOLOR is referenced but not assigned. [SC2154]

--- a/test/fixtures/get_scripts_for_scanning/files.txt
+++ b/test/fixtures/get_scripts_for_scanning/files.txt
@@ -1,0 +1,4 @@
+test/fixtures/get_scripts_for_scanning/files.txt
+test/fixtures/get_scripts_for_scanning/non-script.md
+test/fixtures/get_scripts_for_scanning/script1.sh
+test/fixtures/get_scripts_for_scanning/script2

--- a/test/fixtures/get_scripts_for_scanning/non-script.md
+++ b/test/fixtures/get_scripts_for_scanning/non-script.md
@@ -1,0 +1,3 @@
+# DOCUMENTATION - /bin/bash
+
+- echo "script"

--- a/test/fixtures/get_scripts_for_scanning/script1.sh
+++ b/test/fixtures/get_scripts_for_scanning/script1.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "script"

--- a/test/fixtures/get_scripts_for_scanning/script2
+++ b/test/fixtures/get_scripts_for_scanning/script2
@@ -1,0 +1,3 @@
+# shellcheck shell=bash
+
+echo "script"

--- a/test/get_defects.bats
+++ b/test/get_defects.bats
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+setup_file () {
+  load 'test_helper/common-setup'
+  _common_setup
+}
+
+setup () {
+  load 'test_helper/bats-assert/load'
+  load 'test_helper/bats-support/load'
+  load 'test_helper/bats-file/load'
+}
+
+@test "get_defects()" {
+  source "${PROJECT_ROOT}/src/validation.sh"
+
+  run get_defects
+  assert_failure 1
+
+  run get_defects "arg1"
+  assert_failure 1
+
+  run get_defects "./test/fixtures/get_defects/head.err" "./test/fixtures/get_defects/base.err"
+  assert_success
+  assert_exists ../defects.log
+
+  run cmp -s "../defects.log" "./test/fixtures/get_defects/defects.log"
+  assert_success
+}
+
+teardown () {
+  rm -f ../defects.log
+}

--- a/test/get_fixes.bats
+++ b/test/get_fixes.bats
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+setup_file () {
+  load 'test_helper/common-setup'
+  _common_setup
+}
+
+setup () {
+  load 'test_helper/bats-assert/load'
+  load 'test_helper/bats-support/load'
+  load 'test_helper/bats-file/load'
+}
+
+@test "get_fixes()" {
+  source "${PROJECT_ROOT}/src/validation.sh"
+
+  run get_fixes
+  assert_failure 1
+
+  run get_fixes "arg1"
+  assert_failure 1
+
+  run get_fixes "./test/fixtures/get_fixes/base.err" "./test/fixtures/get_fixes/head.err"
+  assert_success
+  assert_exists ../fixes.log
+
+  run cmp -s "../fixes.log" "./test/fixtures/get_fixes/fixes.log"
+  assert_success
+}
+
+teardown () {
+  rm -f ../fixes.log
+}

--- a/test/get_scripts_for_scanning.bats
+++ b/test/get_scripts_for_scanning.bats
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+setup_file () {
+  load 'test_helper/common-setup'
+  _common_setup
+}
+
+setup () {
+  load 'test_helper/bats-assert/load'
+  load 'test_helper/bats-support/load'
+}
+
+@test "get_scripts_for_scanning()" {
+  source "${PROJECT_ROOT}/src/functions.sh"
+
+  run get_scripts_for_scanning
+  assert_failure 1
+
+  run get_scripts_for_scanning "path"
+  assert_failure 1
+
+  shell_scripts=()
+  run get_scripts_for_scanning "./test/fixtures/get_scripts_for_scanning/files.txt" "shell_scripts"
+  assert_success
+  #! FIXME for some reason I can't get assert_equal to work
+  # assert_equal "${shell_scripts[*]}" "./test/fixtures/get_scripts_for_scanning/script1.sh ./test/fixtures/get_scripts_for_scanning/script2"
+}
+
+teardown () {
+  export \
+    shell_scripts=""
+}

--- a/test/index.bats
+++ b/test/index.bats
@@ -21,6 +21,8 @@ setup () {
 }
 
 teardown () {
+  rm -f ../base-shellcheck.err ../changed-files.txt ../defects.log ../fixes.log ../head-shellcheck.err
+
   export \
     SCRIPT_DIR="" \
     INPUT_TRIGGERING_EVENT="" \

--- a/test/is_full_scan_demanded.bats
+++ b/test/is_full_scan_demanded.bats
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+setup_file () {
+  load 'test_helper/common-setup'
+  _common_setup
+}
+
+setup () {
+  load 'test_helper/bats-assert/load'
+  load 'test_helper/bats-support/load'
+}
+
+@test "is_full_scan_demanded() - trigger event = push" {
+  source "${PROJECT_ROOT}/src/functions.sh"
+
+  INPUT_TRIGGERING_EVENT="push"
+
+  run is_full_scan_demanded
+  assert_success
+}
+
+@test "is_full_scan_demanded() - trigger event = pull_request" {
+  source "${PROJECT_ROOT}/src/functions.sh"
+
+  INPUT_TRIGGERING_EVENT="pull_request"
+
+  run is_full_scan_demanded
+  assert_failure 1
+}
+
+@test "is_full_scan_demanded() - trigger event = manual" {
+  source "${PROJECT_ROOT}/src/functions.sh"
+
+  INPUT_TRIGGERING_EVENT="manual"
+
+  run is_full_scan_demanded
+  assert_failure 1
+
+  INPUT_DIFF_SCAN="false"
+  run is_full_scan_demanded
+  assert_success
+
+  INPUT_DIFF_SCAN="true"
+  run is_full_scan_demanded
+  assert_failure 1
+}
+
+@test "is_full_scan_demanded() - trigger event = empty" {
+  source "${PROJECT_ROOT}/src/functions.sh"
+
+  INPUT_TRIGGERING_EVENT=""
+
+  run is_full_scan_demanded
+  assert_failure 1
+}
+
+teardown () {
+  export \
+    INPUT_TRIGGERING_EVENT="" \
+    INPUT_DIFF_SCAN=""
+}

--- a/test/is_strict_check_on_push_demanded.bats
+++ b/test/is_strict_check_on_push_demanded.bats
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+setup_file () {
+  load 'test_helper/common-setup'
+  _common_setup
+}
+
+setup () {
+  load 'test_helper/bats-assert/load'
+  load 'test_helper/bats-support/load'
+}
+
+@test "is_strict_check_on_push_demanded() - trigger event = push" {
+  source "${PROJECT_ROOT}/src/functions.sh"
+
+  INPUT_TRIGGERING_EVENT="push"
+  INPUT_STRICT_CHECK_ON_PUSH=""
+
+  run is_strict_check_on_push_demanded
+  assert_failure 2
+
+  INPUT_TRIGGERING_EVENT="push"
+  INPUT_STRICT_CHECK_ON_PUSH="false"
+
+  run is_strict_check_on_push_demanded
+  assert_failure 2
+
+  INPUT_TRIGGERING_EVENT="push"
+  INPUT_STRICT_CHECK_ON_PUSH="true"
+
+  run is_strict_check_on_push_demanded
+  assert_success
+}
+
+@test "is_strict_check_on_push_demanded() - trigger event = pull_request" {
+  source "${PROJECT_ROOT}/src/functions.sh"
+
+  INPUT_TRIGGERING_EVENT="pull_request"
+  INPUT_STRICT_CHECK_ON_PUSH=""
+
+  run is_strict_check_on_push_demanded
+  assert_failure 1
+
+  INPUT_TRIGGERING_EVENT="pull_request"
+  INPUT_STRICT_CHECK_ON_PUSH="false"
+
+  run is_strict_check_on_push_demanded
+  assert_failure 1
+
+  INPUT_TRIGGERING_EVENT="pull_request"
+  INPUT_STRICT_CHECK_ON_PUSH="true"
+
+  run is_strict_check_on_push_demanded
+  assert_failure 1
+}
+
+@test "is_strict_check_on_push_demanded() - trigger event = empty" {
+  source "${PROJECT_ROOT}/src/functions.sh"
+
+  INPUT_TRIGGERING_EVENT=""
+
+  run is_strict_check_on_push_demanded
+  assert_failure 1
+}
+
+teardown () {
+  export \
+    INPUT_TRIGGERING_EVENT="" \
+    INPUT_STRICT_CHECK_ON_PUSH=""
+}

--- a/test/pick_base_and_head_hash.bats
+++ b/test/pick_base_and_head_hash.bats
@@ -10,7 +10,7 @@ setup () {
   load 'test_helper/bats-support/load'
 }
 
-@test "pick_base_and_head_hash () - trigger event = push" {
+@test "pick_base_and_head_hash() - trigger event = push" {
   source "${PROJECT_ROOT}/src/functions.sh"
 
   INPUT_TRIGGERING_EVENT="push"
@@ -38,7 +38,7 @@ setup () {
   assert_success
 }
 
-@test "pick_base_and_head_hash () - trigger event = pull_request" {
+@test "pick_base_and_head_hash() - trigger event = pull_request" {
   source "${PROJECT_ROOT}/src/functions.sh"
 
   INPUT_TRIGGERING_EVENT="pull_request"
@@ -66,7 +66,7 @@ setup () {
   assert_success
 }
 
-@test "pick_base_and_head_hash () - trigger event = manual" {
+@test "pick_base_and_head_hash() - trigger event = manual" {
   source "${PROJECT_ROOT}/src/functions.sh"
 
   INPUT_TRIGGERING_EVENT="manual"
@@ -94,7 +94,7 @@ setup () {
   assert_success
 }
 
-@test "pick_base_and_head_hash () - trigger event = empty" {
+@test "pick_base_and_head_hash() - trigger event = empty" {
   source "${PROJECT_ROOT}/src/functions.sh"
 
   INPUT_TRIGGERING_EVENT=""
@@ -104,7 +104,7 @@ setup () {
   assert_failure 1
 }
 
-@test "pick_base_and_head_hash () - trigger event = UNSUPPORTED_VALUE" {
+@test "pick_base_and_head_hash() - trigger event = UNSUPPORTED_VALUE" {
   source "${PROJECT_ROOT}/src/functions.sh"
 
   INPUT_TRIGGERING_EVENT="UNSUPPORTED_VALUE"


### PR DESCRIPTION
This PR changes how we scan the codebase on the `push` event. We will be performing the newly full scan and reporting all results to GitHub in the form of SARIF, but the status check will remain green unless there is some added defect inside pushed changes.

This PR also allows requesting a "strict" status check. When ShellCheck finds a defect during the full scan, the status check will be failed state.

This PR and #165 allow us to support GitHub `push` events natively. Example workflow:

```yml
name: Differential ShellCheck
on:
  push:
  pull_request:
    branches: [main]

permissions:
  contents: read

jobs:
  lint:
    runs-on: ubuntu-latest

    steps:
      - name: Repository checkout
        uses: actions/checkout@v3
        with:
          fetch-depth: 0

      - name: Differential ShellCheck
        uses: redhat-plumbers-in-action/differential-shellcheck@v4
        with:
          token: ${{ secrets.GITHUB_TOKEN }}
```

---

- [x] Implementation
- [x] Unit tests
- [x] Manual testing
- [x] Documentation
- [x] Changelog
- [x] Improve logging