### PR TITLE
doc: avoid hard-coding main branch name

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ name: Differential ShellCheck
 on:
   push:
   pull_request:
-    branches: [ main ]
+    branches: [ $default-branch ]
 
 permissions:
   contents: read


### PR DESCRIPTION
GitHub supports '$default-branch' instead of specifying e.g. 'main' explicitly.
See https://github.blog/changelog/2020-07-22-github-actions-better-support-for-alternative-default-branch-names/ for more info

As requested in https://github.com/redhat-plumbers-in-action/differential-shellcheck/pull/186#discussion_r1072151620