### PR TITLE
Revert "doc: avoid hard-coding main branch name"

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ name: Differential ShellCheck
 on:
   push:
   pull_request:
-    branches: [ $default-branch ]
+    branches: [ main ]
 
 permissions:
   contents: read


### PR DESCRIPTION
Reverts redhat-plumbers-in-action/differential-shellcheck#187