### PR TITLE
Update csutils (csdiff) to 3.0.0 :diamond_shape_with_a_dot_inside: 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ FROM fedora@sha256:f99efcddc4dd6736d8a88cc1ab6722098ec1d77dbf7aed9a7a514fc997ca0
 ARG fedora="37"
 ARG arch="x86_64"
 
-ARG version_csdiff="2.8.0-1"
+ARG version_csdiff="3.0.0-1"
 ARG version_shellcheck="0.8.0-3"
 
 ARG rpm_csdiff="csdiff-${version_csdiff}.fc${fedora}.${arch}.rpm"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v4.1.0
+
+* `grep` - do not escape `#` and `!` in patterns
+* Utilize `DEBUG` to run `grep` without `--silent` option
+* Update `csutils` (`csdiff`) to 3.0.0
+
+## v4.0.2
+
+* Correctly handle character escaping in filenames (e.g. `␣` and `&`)
+* Improve documentation and more tests
+
 ## v4.0.0
 
 * Tag `latest` is no longer available. Use major tags instead (e.g. `v3` or `v4`).

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -7,7 +7,7 @@ FROM fedora@sha256:f99efcddc4dd6736d8a88cc1ab6722098ec1d77dbf7aed9a7a514fc997ca0
 ARG fedora="37"
 ARG arch="x86_64"
 
-ARG version_csdiff="2.9.0-1"
+ARG version_csdiff="3.0.0-1"
 ARG version_shellcheck="0.8.0-3"
 
 ARG rpm_csdiff="csdiff-${version_csdiff}.fc${fedora}.${arch}.rpm"

--- a/test/show_versions.bats
+++ b/test/show_versions.bats
@@ -17,5 +17,5 @@ setup () {
   assert_success
   assert_output \
 "ShellCheck: 0.8.0
-csutils: 2.9.0"
+csutils: 3.0.0"
 }


### PR DESCRIPTION
- https://github.com/csutils/csdiff/pull/68
- https://github.com/csutils/csdiff/issues/102

**Full Changelog**: https://github.com/csutils/csdiff/compare/csdiff-2.8.0...csdiff-3.0.0

The new version of csdiff enables us to use [`github/codeql-action/upload-sarif`](https://github.com/github/codeql-action) for uploading scan results to GitHub.