### PR TITLE
Perform a full scan on pull_request - GitHub will compare scans :goat: 

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,13 +229,15 @@ The name of the event that triggered the workflow run. Supported values are: `pu
 
 ### diff-scan
 
+> **Warning**: _GitHub now compares scanning results as announced in blog post: [Code scanning shows more accurate and relevant alerts on pull requests](https://github.blog/changelog/2023-03-17-code-scanning-shows-more-accurate-and-relevant-alerts-on-pull-requests/). We needed to adopt because this change caused unexpected behavior in form of missing defects and more. Differential ShellCheck will now produce full scan on both `push` and `pull_request` events and leave diff process up to GitHub._
+
 Input allows requesting a specific type of scan. Input is considered only if `triggering-event` is set to `manual`.
 
 Default types of scans based on `triggering-event` input:
 
 | `triggering-event` | type of scan               |
 |--------------------|----------------------------|
-| `pull_request`     | differential               |
+| `pull_request`     | full                       |
 | `push`             | full                       |
 | `manual`           | based on `diff-scan` input |
 

--- a/src/functions.sh
+++ b/src/functions.sh
@@ -16,7 +16,7 @@ is_full_scan_demanded () {
       ;;
 
     "pull_request")
-      return 1
+      return 0
       ;;
 
     "manual")

--- a/src/index.sh
+++ b/src/index.sh
@@ -29,6 +29,8 @@ FULL_SCAN=$?
 if [[ ${FULL_SCAN} -eq 0 ]]; then
   git ls-tree -r --name-only "${HEAD}" > ../files.txt
 
+  unused=
+
   all_scripts=()
   get_scripts_for_scanning "../files.txt" "all_scripts"
 fi

--- a/src/index.sh
+++ b/src/index.sh
@@ -27,7 +27,7 @@ is_full_scan_demanded
 FULL_SCAN=$?
 
 if [[ ${FULL_SCAN} -eq 0 ]]; then
-  git ls-tree -r --name-only "${GITHUB_REF_NAME-"main"}" > ../files.txt
+  git ls-tree -r --name-only "${HEAD}" > ../files.txt
 
   all_scripts=()
   get_scripts_for_scanning "../files.txt" "all_scripts"


### PR DESCRIPTION
GitHub now compares scanning results as announced in a blog post: [Code scanning shows more accurate and relevant alerts on pull requests](https://github.blog/changelog/2023-03-17-code-scanning-shows-more-accurate-and-relevant-alerts-on-pull-requests/)

We needed to adopt because this change caused unexpected behavior in the form of missing defects and more. Differential ShellCheck will now produce a full scan on both `push` and `pull_request` events and leave compare process up to GitHub.