### PR TITLE
Revert "Use `github/codeql-action/upload-sarif` :octocat: "

### DIFF
--- a/.github/workflows/differential-shellcheck.yml
+++ b/.github/workflows/differential-shellcheck.yml
@@ -39,17 +39,12 @@ jobs:
         uses: ./
         with:
           shell-scripts: .github/.differential-shellcheck-scripts.txt
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - if: ${{ always() }}
-        name: Upload artifact with ShellCheck defects in SARIF format
+        name: Upload artifact with defects in SARIF format
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
         with:
           name: Differential ShellCheck SARIF
           path: ${{ steps.ShellCheck.outputs.sarif }}
           retention-days: 7
-
-      - if: ${{ always() }}
-        name: Upload SARIF to GitHub using github/codeql-action/upload-sarif
-        uses: github/codeql-action/upload-sarif@bb28e7e59e2ad6c1e5400e671795b2fa1b2fca6f
-        with:
-          sarif_file: ${{ steps.ShellCheck.outputs.sarif }}

--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ jobs:
       - id: ShellCheck
         name: Differential ShellCheck
         uses: redhat-plumbers-in-action/differential-shellcheck@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - if: ${{ always() }}
         name: Upload artifact with ShellCheck defects in SARIF format
@@ -99,12 +101,6 @@ jobs:
         with:
           name: Differential ShellCheck SARIF
           path: ${{ steps.ShellCheck.outputs.sarif }}
-
-      - if: ${{ always() }}
-        name: Upload SARIF to GitHub using github/codeql-action/upload-sarif
-        uses: github/codeql-action/upload-sarif@v2
-        with:
-          sarif_file: ${{ steps.ShellCheck.outputs.sarif }}
 ```
 
 > **Warning**: _`fetch-depth: 0` is required to run `differential-shellcheck` successfully. It fetches all git history._

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,7 +5,6 @@
 * `grep` - do not escape `#` and `!` in patterns
 * Utilize `DEBUG` to run `grep` without `--silent` option
 * Update `csutils` (`csdiff`) to 3.0.0
-* Update example - suggest `github/codeql-action/upload-sarif` as default way how to upload SARIF
 
 ## v4.0.2
 


### PR DESCRIPTION
Reverts redhat-plumbers-in-action/differential-shellcheck#225

It doesn't work as expected, and needs further investigation and testing ...

- #226 