### PR TITLE
Add Statistics of defect severities :bar_chart: 

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ To evaluate results, Differential ShellCheck uses utilities `csdiff` and `csgrep
   * support for [`emacs` modes specifications](https://www.gnu.org/software/emacs/manual/html_node/emacs/Choosing-Modes.html) ; e.g. `# -*- sh -*-`
   * support for [`vi/vim` modeline specifications](http://vimdoc.sourceforge.net/htmldoc/options.html#modeline) ; e.g. `# vi: set filetype=sh`, `# vim: ft=sh`
 * Ability to allowlist specific error codes
-* Statistics about fixed and added errors
+* Statistics about fixed and added defects and their severity
 * Colored console output with emojis
 * [SARIF support](https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning) - warnings are visible in the `Changed files` tab of the Pull-Request and as [comment alerts on Pull-Requests](https://github.blog/changelog/2022-06-02-users-can-view-and-comment-on-code-scanning-alerts-on-the-conversation-tab-in-a-pull-request/)
 * Ability to run in a verbose mode when run with [debug option](https://github.blog/changelog/2022-05-24-github-actions-re-run-jobs-with-debug-logging/)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next release
 
+* Added defect statistics based on severity levels. They are available in the console output and in the job Summary page.
 * Fix detection of changed files that might cause failure on paths with special characters.
 * Drop support for `shell-scripts` input
 * Drop support for `ignored-codes` input

--- a/src/index.sh
+++ b/src/index.sh
@@ -49,7 +49,7 @@ show_versions
 echo -e "${MAIN_HEADING}"
 
 echo -e "::group::📜 ${WHITE}List of shell scripts for scanning${NOCOLOR}"
-echo "${all_scripts[@]:-${only_changed_scripts[@]}}"
+  echo "${all_scripts[@]:-${only_changed_scripts[@]}}"
 echo "::endgroup::"
 echo
 

--- a/src/summary.sh
+++ b/src/summary.sh
@@ -111,6 +111,7 @@ link_to_results () {
   esac 
 }
 
+# Print statistics of defects in form of table
 summary_defect_statistics () {
   echo -e "\
 #### New defects statistics

--- a/src/summary.sh
+++ b/src/summary.sh
@@ -10,6 +10,9 @@ summary () {
     scan_summary=$(diff_scan_summary)
   fi
 
+  local defect_statistics=""
+  defect_statistics=$(summary_defect_statistics)
+
   local useful_links=
   useful_links=$(summary_useful_links)
   
@@ -17,6 +20,8 @@ summary () {
 ### Differential ShellCheck 🐚
 
 ${scan_summary}
+
+${defect_statistics}
 
 ${useful_links}"
 }
@@ -104,6 +109,15 @@ link_to_results () {
     *)
       echo -e ""
   esac 
+}
+
+summary_defect_statistics () {
+  echo -e "\
+#### New defects statistics
+
+|          | 👕 Style                 | 🗒️ Note                 | ⚠️ Warning                 | 🛑 Error                 |
+|:--------:|:------------------------:|:-----------------------:|:--------------------------:|:------------------------:|
+| 🔢 Count | **${stat_style:-"N/A"}** | **${stat_note:-"N/A"}** | **${stat_warning:-"N/A"}** | **${stat_error:-"N/A"}** |"
 }
 
 # Print useful information at the end of summary report

--- a/src/validation.sh
+++ b/src/validation.sh
@@ -83,6 +83,7 @@ get_number_of_defects_by_severity () {
   local logs="$2"
   local defects=0
 
+  [[ -f "${logs}" ]] || return 1
   defects=$(grep --count --extended-regexp "^[^:]+:[0-9]+:[0-9]+: ${severity}\[SC[0-9]+\].*$" "${logs}")
   echo "${defects}"
 }

--- a/src/validation.sh
+++ b/src/validation.sh
@@ -54,6 +54,8 @@ evaluate_and_print_defects () {
   echo -e "🥳 ${GREEN}No defects added. Yay!${NOCOLOR}"
 }
 
+# Function to print statistics of defects
+# it requires gather_statistics to be called first
 print_statistics () {
   echo -e "::group::📊 ${WHITE}Statistics of defects${NOCOLOR}"
     [[ -n ${stat_error} ]] && echo -e "Error: ${stat_error}"
@@ -65,6 +67,8 @@ print_statistics () {
 }
 
 # Function to filter out defects by their severity level
+# It sets global variables stat_error, stat_warning, stat_note, stat_style depending on INPUT_SEVERITY
+# $1 - <string> absolute path to a file containing defects detected by scan in gcc format
 gather_statistics () {
   [[ $# -le 0 ]] && return 1
   local logs="$1"
@@ -77,6 +81,9 @@ gather_statistics () {
   export stat_style stat_note stat_warning stat_error
 }
 
+# Function to get number of defects by severity level
+# $1 - <string> severity level
+# $2 - <string> absolute path to a file containing defects detected by scan in gcc format
 get_number_of_defects_by_severity () {
   [[ $# -le 1 ]] && return 1
   local severity="$1"

--- a/test/evaluate_and_print_defects.bats
+++ b/test/evaluate_and_print_defects.bats
@@ -13,11 +13,19 @@ setup () {
 @test "evaluate_and_print_defects() - some defects" {
   source "${PROJECT_ROOT}/src/validation.sh"
 
+  INPUT_SEVERITY="style"
   cp ./test/fixtures/evaluate_and_print_defects/defects.log ../defects.log
 
   run evaluate_and_print_defects
   assert_failure 1
   assert_output "\
+::group::📊 Statistics of defects
+Error: 0
+Warning: 3
+Note: 0
+Style: 0
+::endgroup::
+
 ✋ Defects, NEEDS INSPECTION
 Error: SHELLCHECK_WARNING:
 src/index.sh:53:10: warning[SC2154]: MAIN_HEADING is referenced but not assigned.

--- a/test/evaluate_and_print_fixes.bats
+++ b/test/evaluate_and_print_fixes.bats
@@ -13,11 +13,15 @@ setup () {
 @test "evaluate_and_print_fixes() - some fixes" {
   source "${PROJECT_ROOT}/src/validation.sh"
 
+  INPUT_SEVERITY="style"
   cp ./test/fixtures/evaluate_and_print_fixes/fixes.log ../fixes.log
 
   run evaluate_and_print_fixes
   assert_success
   assert_output "\
+::group::📊 Statistics of defects
+::endgroup::
+
 ✅ Fixed defects
 Error: SHELLCHECK_WARNING:
 src/index.sh:7:3: note[SC1091]: Not following: functions.sh: openBinaryFile: does not exist (No such file or directory)"

--- a/test/fixtures/gather_statistics/defects.log
+++ b/test/fixtures/gather_statistics/defects.log
@@ -1,0 +1,8 @@
+Error: SHELLCHECK_WARNING:
+src/index.sh:53:10: warning[SC2154]: MAIN_HEADING is referenced but not assigned.
+
+Error: SHELLCHECK_WARNING:
+src/index.sh:56:14: warning[SC2154]: WHITE is referenced but not assigned.
+
+Error: SHELLCHECK_WARNING:
+src/index.sh:56:56: warning[SC2154]: NOCOLOR is referenced but not assigned.

--- a/test/fixtures/get_number_of_defects_by_severity/defects.log
+++ b/test/fixtures/get_number_of_defects_by_severity/defects.log
@@ -1,0 +1,8 @@
+Error: SHELLCHECK_WARNING:
+src/index.sh:53:10: warning[SC2154]: MAIN_HEADING is referenced but not assigned.
+
+Error: SHELLCHECK_WARNING:
+src/index.sh:56:14: warning[SC2154]: WHITE is referenced but not assigned.
+
+Error: SHELLCHECK_WARNING:
+src/index.sh:56:56: warning[SC2154]: NOCOLOR is referenced but not assigned.

--- a/test/fixtures/print_statistics/defects.log
+++ b/test/fixtures/print_statistics/defects.log
@@ -1,0 +1,8 @@
+Error: SHELLCHECK_WARNING:
+src/index.sh:53:10: warning[SC2154]: MAIN_HEADING is referenced but not assigned.
+
+Error: SHELLCHECK_WARNING:
+src/index.sh:56:14: warning[SC2154]: WHITE is referenced but not assigned.
+
+Error: SHELLCHECK_WARNING:
+src/index.sh:56:56: warning[SC2154]: NOCOLOR is referenced but not assigned.

--- a/test/gather_statistics.bats
+++ b/test/gather_statistics.bats
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+setup_file () {
+  load 'test_helper/common-setup'
+  _common_setup
+}
+
+setup () {
+  load 'test_helper/bats-assert/load'
+  load 'test_helper/bats-support/load'
+}
+
+@test "gather_statistics() - general" {
+  source "${PROJECT_ROOT}/src/validation.sh"
+
+  INPUT_SEVERITY="style"
+
+  run gather_statistics
+  assert_failure 1
+
+  run gather_statistics "./test/fixtures/gather_statistics/defects.log"
+  assert_success
+}

--- a/test/get_number_of_defects_by_severity.bats
+++ b/test/get_number_of_defects_by_severity.bats
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+setup_file () {
+  load 'test_helper/common-setup'
+  _common_setup
+}
+
+setup () {
+  load 'test_helper/bats-assert/load'
+  load 'test_helper/bats-support/load'
+}
+
+@test "get_number_of_defects_by_severity() - general" {
+  source "${PROJECT_ROOT}/src/validation.sh"
+
+  run get_number_of_defects_by_severity
+  assert_failure 1
+
+  run get_number_of_defects_by_severity "arg1"
+  assert_failure 1
+
+  run get_number_of_defects_by_severity "warning" "./test/fixtures/get_number_of_defects_by_severity/defects.log"
+  assert_success
+  assert_output "3"
+
+  run get_number_of_defects_by_severity "error" "./test/fixtures/get_number_of_defects_by_severity/defects.log"
+  assert_success
+  assert_output "0"
+}

--- a/test/print_statistics.bats
+++ b/test/print_statistics.bats
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+setup_file () {
+  load 'test_helper/common-setup'
+  _common_setup
+}
+
+setup () {
+  load 'test_helper/bats-assert/load'
+  load 'test_helper/bats-support/load'
+}
+
+@test "print_statistics() - severity=style" {
+  source "${PROJECT_ROOT}/src/validation.sh"
+
+  INPUT_SEVERITY="style"
+  gather_statistics "./test/fixtures/print_statistics/defects.log"
+  run print_statistics
+  assert_success
+  assert_output \
+"::group::📊 Statistics of defects
+Error: 0
+Warning: 3
+Note: 0
+Style: 0
+::endgroup::"
+}
+
+@test "print_statistics() - severity=warning" {
+  source "${PROJECT_ROOT}/src/validation.sh"
+
+  INPUT_SEVERITY="warning"
+  gather_statistics "./test/fixtures/print_statistics/defects.log"
+  run print_statistics
+  assert_success
+  assert_output \
+"::group::📊 Statistics of defects
+Error: 0
+Warning: 3
+::endgroup::"
+}

--- a/test/summary.bats
+++ b/test/summary.bats
@@ -10,12 +10,13 @@ setup () {
   load 'test_helper/bats-support/load'
 }
 
-@test "summary()" {
+@test "summary() - general" {
   source "${PROJECT_ROOT}/src/functions.sh"
   source "${PROJECT_ROOT}/src/summary.sh"
 
   export only_changed_scripts=("1.sh" "\$2.sh" "3 .sh")
   INPUT_TRIGGERING_EVENT=""
+  INPUT_SEVERITY="style"
 
   echo -e \
 "Error: SHELLCHECK_WARNING:
@@ -44,6 +45,12 @@ Changed scripts: \`3\`
 |:------------------:|:------------------------:|:------------------------:|
 | ⚠️ Errors / Warnings / Notes |  **3**  |  **1**  |
 
+#### New defects statistics
+
+|          | 👕 Style                 | 🗒️ Note                 | ⚠️ Warning                 | 🛑 Error                 |
+|:--------:|:------------------------:|:-----------------------:|:--------------------------:|:------------------------:|
+| 🔢 Count | **N/A** | **N/A** | **N/A** | **N/A** |
+
 #### Useful links
 
 - [Differential ShellCheck Documentation](https://github.com/redhat-plumbers-in-action/differential-shellcheck#readme)
@@ -59,6 +66,7 @@ _ℹ️ If you have an issue with this GitHub action, please try to run it in th
 
   export only_changed_scripts=("1.sh" "\$2.sh" "3 .sh")
   INPUT_TRIGGERING_EVENT="push"
+  INPUT_SEVERITY="style"
   GITHUB_REPOSITORY="test-user/test-repo"
   GITHUB_REF_NAME="test-branch"
   SCANNING_TOOL="not-shellcheck"
@@ -91,6 +99,12 @@ Changed scripts: \`3\`
 |:------------------:|:------------------------:|:------------------------:|
 | ⚠️ [Errors / Warnings / Notes](https://github.com/${GITHUB_REPOSITORY}/security/code-scanning?query=tool%3A${SCANNING_TOOL}+branch%3A${GITHUB_REF_NAME}+is%3Aopen) |  **3**  |  **1**  |
 
+#### New defects statistics
+
+|          | 👕 Style                 | 🗒️ Note                 | ⚠️ Warning                 | 🛑 Error                 |
+|:--------:|:------------------------:|:-----------------------:|:--------------------------:|:------------------------:|
+| 🔢 Count | **N/A** | **N/A** | **N/A** | **N/A** |
+
 #### Useful links
 
 - [Differential ShellCheck Documentation](https://github.com/redhat-plumbers-in-action/differential-shellcheck#readme)
@@ -106,6 +120,7 @@ _ℹ️ If you have an issue with this GitHub action, please try to run it in th
 
   export only_changed_scripts=("1.sh" "\$2.sh" "3 .sh")
   INPUT_TRIGGERING_EVENT="pull_request"
+  INPUT_SEVERITY="style"
   GITHUB_REPOSITORY="test-user/test-repo"
   PR_NUMBER=123
   SCANNING_TOOL="not-shellcheck"
@@ -138,6 +153,12 @@ Changed scripts: \`3\`
 |:------------------:|:------------------------:|:------------------------:|
 | ⚠️ [Errors / Warnings / Notes](https://github.com/${GITHUB_REPOSITORY}/security/code-scanning?query=pr%3A${PR_NUMBER}+tool%3A${SCANNING_TOOL}+is%3Aopen) |  **3**  |  **1**  |
 
+#### New defects statistics
+
+|          | 👕 Style                 | 🗒️ Note                 | ⚠️ Warning                 | 🛑 Error                 |
+|:--------:|:------------------------:|:-----------------------:|:--------------------------:|:------------------------:|
+| 🔢 Count | **N/A** | **N/A** | **N/A** | **N/A** |
+
 #### Useful links
 
 - [Differential ShellCheck Documentation](https://github.com/redhat-plumbers-in-action/differential-shellcheck#readme)
@@ -153,6 +174,7 @@ _ℹ️ If you have an issue with this GitHub action, please try to run it in th
 
   export only_changed_scripts=("1.sh" "\$2.sh" "3 .sh")
   INPUT_TRIGGERING_EVENT=""
+  INPUT_SEVERITY="style"
 
   touch ../defects.log ../fixes.log
 
@@ -166,6 +188,12 @@ Changed scripts: \`3\`
 |                    | ❌ Added                 | ✅ Fixed                 |
 |:------------------:|:------------------------:|:------------------------:|
 | ⚠️ Errors / Warnings / Notes |  **0**  |  **0**  |
+
+#### New defects statistics
+
+|          | 👕 Style                 | 🗒️ Note                 | ⚠️ Warning                 | 🛑 Error                 |
+|:--------:|:------------------------:|:-----------------------:|:--------------------------:|:------------------------:|
+| 🔢 Count | **N/A** | **N/A** | **N/A** | **N/A** |
 
 #### Useful links
 
@@ -182,6 +210,7 @@ _ℹ️ If you have an issue with this GitHub action, please try to run it in th
 
   export only_changed_scripts=()
   INPUT_TRIGGERING_EVENT=""
+  INPUT_SEVERITY="style"
 
   touch ../defects.log ../fixes.log
 
@@ -195,6 +224,12 @@ Changed scripts: \`0\`
 |                    | ❌ Added                 | ✅ Fixed                 |
 |:------------------:|:------------------------:|:------------------------:|
 | ⚠️ Errors / Warnings / Notes |  **0**  |  **0**  |
+
+#### New defects statistics
+
+|          | 👕 Style                 | 🗒️ Note                 | ⚠️ Warning                 | 🛑 Error                 |
+|:--------:|:------------------------:|:-----------------------:|:--------------------------:|:------------------------:|
+| 🔢 Count | **N/A** | **N/A** | **N/A** | **N/A** |
 
 #### Useful links
 
@@ -211,6 +246,7 @@ _ℹ️ If you have an issue with this GitHub action, please try to run it in th
 
   export all_scripts=("1.sh" "\$2.sh" "3 .sh")
   INPUT_TRIGGERING_EVENT=""
+  INPUT_SEVERITY="style"
   FULL_SCAN=0
 
   echo -e \
@@ -240,6 +276,12 @@ Changed scripts: \`0\`
 |:------------------:|:------------------------:|:------------------------:|
 | ⚠️ Errors / Warnings / Notes |  **3**  |  **1**  |
 
+#### New defects statistics
+
+|          | 👕 Style                 | 🗒️ Note                 | ⚠️ Warning                 | 🛑 Error                 |
+|:--------:|:------------------------:|:-----------------------:|:--------------------------:|:------------------------:|
+| 🔢 Count | **N/A** | **N/A** | **N/A** | **N/A** |
+
 #### Useful links
 
 - [Differential ShellCheck Documentation](https://github.com/redhat-plumbers-in-action/differential-shellcheck#readme)
@@ -255,6 +297,7 @@ _ℹ️ If you have an issue with this GitHub action, please try to run it in th
 
   export all_scripts=("1.sh" "\$2.sh" "3 .sh")
   INPUT_TRIGGERING_EVENT="push"
+  INPUT_SEVERITY="style"
   GITHUB_REPOSITORY="test-user/test-repo"
   GITHUB_REF_NAME="test-branch"
   SCANNING_TOOL="not-shellcheck"
@@ -287,6 +330,12 @@ Number of scripts: \`3\`
 
 [Defects](https://github.com/${GITHUB_REPOSITORY}/security/code-scanning?query=tool%3A${SCANNING_TOOL}+branch%3A${GITHUB_REF_NAME}+is%3Aopen): **3**
 
+#### New defects statistics
+
+|          | 👕 Style                 | 🗒️ Note                 | ⚠️ Warning                 | 🛑 Error                 |
+|:--------:|:------------------------:|:-----------------------:|:--------------------------:|:------------------------:|
+| 🔢 Count | **N/A** | **N/A** | **N/A** | **N/A** |
+
 #### Useful links
 
 - [Differential ShellCheck Documentation](https://github.com/redhat-plumbers-in-action/differential-shellcheck#readme)
@@ -302,6 +351,7 @@ teardown () {
   export \
     only_changed_scripts="" \
     INPUT_TRIGGERING_EVENT="" \
+    INPUT_SEVERITY="" \
     GITHUB_REPOSITORY="" \
     GITHUB_REF_NAME="" \
     SCANNING_TOOL="" \

--- a/test/summary_defect_statistics.bats
+++ b/test/summary_defect_statistics.bats
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+setup_file () {
+  load 'test_helper/common-setup'
+  _common_setup
+}
+
+setup () {
+  load 'test_helper/bats-assert/load'
+  load 'test_helper/bats-support/load'
+}
+
+@test "summary_defect_statistics() - all N/A" {
+  source "${PROJECT_ROOT}/src/summary.sh"
+
+  run summary_defect_statistics
+  assert_success
+  assert_output \
+"#### New defects statistics
+
+|          | 👕 Style                 | 🗒️ Note                 | ⚠️ Warning                 | 🛑 Error                 |
+|:--------:|:------------------------:|:-----------------------:|:--------------------------:|:------------------------:|
+| 🔢 Count | **N/A** | **N/A** | **N/A** | **N/A** |"
+}
+
+@test "summary_defect_statistics() - general" {
+  source "${PROJECT_ROOT}/src/summary.sh"
+
+  stat_warning=10
+  stat_error=0
+
+  run summary_defect_statistics
+  assert_success
+  assert_output \
+"#### New defects statistics
+
+|          | 👕 Style                 | 🗒️ Note                 | ⚠️ Warning                 | 🛑 Error                 |
+|:--------:|:------------------------:|:-----------------------:|:--------------------------:|:------------------------:|
+| 🔢 Count | **N/A** | **N/A** | **10** | **0** |"
+}
+
+


### PR DESCRIPTION
Let's add statistics about the type and count of new defects.

Example of statistics in console output for `severity: warning`:

![Screenshot from 2023-08-11 13-22-39](https://github.com/redhat-plumbers-in-action/differential-shellcheck/assets/2879818/5c7f5dcb-f957-4300-9d24-4262852fd97d)

Example of statistics in job summary output for `severity: warning`:

![Screenshot from 2023-08-11 13-21-31](https://github.com/redhat-plumbers-in-action/differential-shellcheck/assets/2879818/5c41f49f-1c4b-4038-b022-6aec36d86bb5)

---

- [x] Add tests
- [x] Add documentation in README
- [x] Add documentation of functions
- [x] Add CHANGELOG
- [x] Test functionality