### PR TITLE
Handle multiple include/exclude paths with newlines :earth_africa: 

### DIFF
--- a/.github/workflows/differential-shellcheck.yml
+++ b/.github/workflows/differential-shellcheck.yml
@@ -39,7 +39,9 @@ jobs:
         uses: ./
         with:
           shell-scripts: .github/.differential-shellcheck-scripts.txt
-          exclude-path: test/**
+          exclude-path: |
+            test/**
+            src/**.{zsh,osh}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - if: ${{ always() }}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v4.2.1
+
+* Handle multiple include/exclude paths with newlines
+
 ## v4.2.0
 
 * New option `exclude-path`. Allows to specify list of paths excluded from ShellCheck scanning. It supports globbing and brace expansion. e.g. `test/{test1,test2}/**`

--- a/src/functions.sh
+++ b/src/functions.sh
@@ -208,10 +208,14 @@ is_directory () {
 is_matched_by_path () {
   [[ $# -le 1 ]] && return 1
   local file="$1"
-  local file_paths="$2"
+
+  # When multiple paths are provided they might be separated by space and/or newline, lets replace all newlines with spaces in order to avoid issues with glob pattern matching in eval
+  # /action/functions.sh: line 215: tests/**: No such file or directory
+  local file_paths=""
+  file_paths=$(tr '\r\n' ' ' <<< "$2")
 
   set -f
-  globs=$(eval "echo ${file_paths-""}")
+  globs=$(eval "echo ${file_paths}")
 
   for pattern in ${globs}; do
     # shellcheck disable=SC2053

--- a/test/is_matched_by_path.bats
+++ b/test/is_matched_by_path.bats
@@ -61,6 +61,19 @@ setup () {
   assert_success
 }
 
+@test "is_matched_by_path() - matching - multiline input" {
+  source "${PROJECT_ROOT}/src/functions.sh"
+
+  INPUT_EXCLUDE_PATH="test/{**,*,}
+test/**
+1.sh"
+
+  run is_matched_by_path "test/1.sh" "${INPUT_EXCLUDE_PATH}"
+  assert_success
+  run is_matched_by_path "1.sh" "${INPUT_EXCLUDE_PATH}"
+  assert_success
+}
+
 @test "is_matched_by_path() - bad number of arguments" {
   source "${PROJECT_ROOT}/src/functions.sh"
 


### PR DESCRIPTION
When multiple paths are specified using the `|` operator in YAML, the resulting string contains newlines.
When this string is passed to `globs=$(eval "echo ${file_paths}")` bash is trying to execute paths as commend and fails with the error:

```sh
/action/functions.sh: line 215: tests/**: No such file or directory
```

We can avoid this error by replacing newlines with spaces from the paths.