### PR TITLE
Add support for subdirectory scanning :file_folder: 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 coverage
 .vscode
+
+*.sarif

--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ Action currently accepts following options:
     strict-check-on-push: <true or false>
     external-sources: <true or false>
     severity: <minimal severity level>
+    scan-directory: <list of paths>
     exclude-path: <list of paths>
     include-path: <list of paths>
     token: <GitHub token>
@@ -258,6 +259,17 @@ Minimal severity level of detected errors that will be reported. Valid values in
 
 * default value: `style`
 * requirements: `optional`
+
+### scan-directory
+
+List of relative paths to directories that will be scanned for shell scripts. Globbing is supported.
+
+By default the whole repository is scanned. This feature is useful when you want to scan only a subset of the repository.
+
+This feature is fully compatible with [exclude-path](#exclude-path) and [include-path](#include-path) options.
+
+* requirements: `optional`
+* example: `"build/**"`
 
 ### exclude-path
 

--- a/action.yml
+++ b/action.yml
@@ -62,6 +62,11 @@ inputs:
     description: Specify minimum severity of errors to consider. Valid values in order of severity are error, warning, info and style. The default is style.
     default: style
     required: false
+
+  scan-directory:
+    description: Directory to scan. If not specified, the root directory is scanned.
+    default: ''
+    required: false
   exclude-path:
     description: List of paths excluded from ShellCheck scanning.
     default: ''
@@ -91,5 +96,6 @@ runs:
     INPUT_DIFF_SCAN: ${{ inputs.diff-scan }}
     INPUT_STRICT_CHECK_ON_PUSH: ${{ inputs.strict-check-on-push }}
     INPUT_EXTERNAL_SOURCES: ${{ inputs.external-sources }}
+    INPUT_SCAN_DIRECTORY: ${{ inputs.scan-directory }}
     INPUT_EXCLUDE_PATH: ${{ inputs.exclude-path }}
     INPUT_INCLUDE_PATH: ${{ inputs.include-path }}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Next release
 
 * Added defect statistics based on severity levels. They are available in the console output and in the job Summary page.
+* New option `scan-directory`. Allows to specify directories that will be scanned. By default Differential ShellCheck scans the whole repository.
 * Fix detection of changed files that might cause failure on paths with special characters.
 * Drop support for `shell-scripts` input
 * Drop support for `ignored-codes` input

--- a/src/functions.sh
+++ b/src/functions.sh
@@ -222,12 +222,24 @@ file_to_array () {
   local output=()
 
   while IFS= read -r -d '' file; do
+    is_file_inside_scan_directory "${file}" || continue
     output+=("${file}")
   done < "${1}"
 
   [[ ${UNIT_TESTS:-1} -eq 0 ]] && echo "${output[@]}"
 
   eval "${2}"=\("${output[*]@Q}"\)
+}
+
+# Function to test if given file is inside the scan directory
+# $1 - <string> file path
+# $? - return value - 0 on success
+is_file_inside_scan_directory () {
+  [[ $# -le 0 ]] && return 1
+  [[ -z "${INPUT_SCAN_DIRECTORY}" ]] && return 0
+
+  is_matched_by_path "${file}" "${INPUT_SCAN_DIRECTORY}"
+  return $?
 }
 
 # Evaluate if variable contains true value

--- a/test/is_file_inside_scan_directory.bats
+++ b/test/is_file_inside_scan_directory.bats
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+setup_file () {
+  load 'test_helper/common-setup'
+  _common_setup
+}
+
+setup () {
+  load 'test_helper/bats-assert/load'
+  load 'test_helper/bats-support/load'
+}
+
+@test "is_file_inside_scan_directory() - general" {
+  source "${PROJECT_ROOT}/src/functions.sh"
+
+  run is_file_inside_scan_directory
+  assert_failure 1
+
+  INPUT_SCAN_DIRECTORY=""
+  run is_file_inside_scan_directory "test/test.sh"
+  assert_success
+
+  # !FIXME: This is working in real life, but not in tests \o/
+  # INPUT_SCAN_DIRECTORY="test/**"
+  # run is_file_inside_scan_directory "test/script.sh"
+  # assert_success
+
+  INPUT_SCAN_DIRECTORY="src/**"
+  run is_file_inside_scan_directory "test/test.sh"
+  assert_failure 2
+}
+
+function teardown() {
+  export INPUT_SCAN_DIRECTORY=""
+}


### PR DESCRIPTION
Using the new input parameter `scan-directory`, it is now possible to scan only the specified subdirectory of the repository.

The detection of shell scripts will be performed on files inside the scan directory only. It can be combined with the `exclude-path` and `include-path` inputs.

---

- [x] test functionality
- [x] add tests
- [x] add documentation with an example
- [x] add changelog