### PR TITLE
Fix autodetection of shell scripts in DEBUG mode :kiwi_fruit: 

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Added defect statistics based on severity levels. They are available in the console output and in the job Summary page.
 * New option `scan-directory`. Allows to specify directories that will be scanned. By default Differential ShellCheck scans the whole repository.
+* Fix autodetection of shell scripts in DEBUG mode
 * Fix detection of changed files that might cause failure on paths with special characters.
 * Fix count of scanned files in job Summary when running on push event.
 * Drop support for `shell-scripts` input

--- a/src/functions.sh
+++ b/src/functions.sh
@@ -131,29 +131,23 @@ has_shebang () {
   [[ $# -le 0 ]] && return 1
   local file="$1"
 
-  ! is_debug && local quiet=--quiet
-
-  local grep_args=(
-    "${quiet:-}"
-  )
-
   # shell shebangs detection
-  if head -n1 "${file}" | grep "${grep_args[@]}" -E '^\s*((#|!)|(#\s*!)|(!\s*#))\s*(/usr(/local)?)?/bin/(env\s+)?(sh|ash|bash|dash|ksh|bats)\b'; then
+  if head -n1 "${file}" | grep ${RUNNER_DEBUG:+"--quiet"} -E '^\s*((#|!)|(#\s*!)|(!\s*#))\s*(/usr(/local)?)?/bin/(env\s+)?(sh|ash|bash|dash|ksh|bats)\b'; then
     return 0
   fi
 
   # ShellCheck shell directive detection
-  if grep "${grep_args[@]}" -E '^\s*#\s*shellcheck\s+shell=(sh|ash|bash|dash|ksh|bats)\s*' "${file}"; then
+  if grep  ${RUNNER_DEBUG:+"--quiet"} -E '^\s*#\s*shellcheck\s+shell=(sh|ash|bash|dash|ksh|bats)\s*' "${file}"; then
     return 0
   fi
 
   # Emacs mode detection
-  if grep "${grep_args[@]}" -E '^\s*#\s+-\*-\s+(sh|ash|bash|dash|ksh|bats)\s+-\*-\s*' "${file}"; then
+  if grep  ${RUNNER_DEBUG:+"--quiet"} -E '^\s*#\s+-\*-\s+(sh|ash|bash|dash|ksh|bats)\s+-\*-\s*' "${file}"; then
     return 0
   fi
 
   # Vi and Vim modeline filetype detection
-  if grep "${grep_args[@]}" -E '^\s*#\s+vim?:\s+(set\s+)?(ft|filetype)=(sh|ash|bash|dash|ksh|bats)\s*' "${file}"; then
+  if grep  ${RUNNER_DEBUG:+"--quiet"} -E '^\s*#\s+vim?:\s+(set\s+)?(ft|filetype)=(sh|ash|bash|dash|ksh|bats)\s*' "${file}"; then
     return 0
   fi
 


### PR DESCRIPTION
In DEBUG mode, `head` and `grep` was incorrectly called with `''`.

This caused warnings like:
`grep: ^\s*((#|!)|(#\s*!)|(!\s*#))\s*(/usr(/local)?)?/bin/(env\s+)?(sh|ash|bash|dash|ksh|bats)\b: No such file or directory`

In the end, Differential ShellCheck, in some cases, couldn't identify shell scripts correctly in DEBUG mode.