### PR TITLE
Drop support for DEBUG in grep :bug: 

### DIFF
--- a/src/functions.sh
+++ b/src/functions.sh
@@ -132,22 +132,22 @@ has_shebang () {
   local file="$1"
 
   # shell shebangs detection
-  if head -n1 "${file}" | grep ${RUNNER_DEBUG:+"--quiet"} -E '^\s*((#|!)|(#\s*!)|(!\s*#))\s*(/usr(/local)?)?/bin/(env\s+)?(sh|ash|bash|dash|ksh|bats)\b'; then
+  if head -n1 "${file}" | grep --quiet -E '^\s*((#|!)|(#\s*!)|(!\s*#))\s*(/usr(/local)?)?/bin/(env\s+)?(sh|ash|bash|dash|ksh|bats)\b'; then
     return 0
   fi
 
   # ShellCheck shell directive detection
-  if grep  ${RUNNER_DEBUG:+"--quiet"} -E '^\s*#\s*shellcheck\s+shell=(sh|ash|bash|dash|ksh|bats)\s*' "${file}"; then
+  if grep --quiet -E '^\s*#\s*shellcheck\s+shell=(sh|ash|bash|dash|ksh|bats)\s*' "${file}"; then
     return 0
   fi
 
   # Emacs mode detection
-  if grep  ${RUNNER_DEBUG:+"--quiet"} -E '^\s*#\s+-\*-\s+(sh|ash|bash|dash|ksh|bats)\s+-\*-\s*' "${file}"; then
+  if grep --quiet -E '^\s*#\s+-\*-\s+(sh|ash|bash|dash|ksh|bats)\s+-\*-\s*' "${file}"; then
     return 0
   fi
 
   # Vi and Vim modeline filetype detection
-  if grep  ${RUNNER_DEBUG:+"--quiet"} -E '^\s*#\s+vim?:\s+(set\s+)?(ft|filetype)=(sh|ash|bash|dash|ksh|bats)\s*' "${file}"; then
+  if grep --quiet -E '^\s*#\s+vim?:\s+(set\s+)?(ft|filetype)=(sh|ash|bash|dash|ksh|bats)\s*' "${file}"; then
     return 0
   fi
 

--- a/src/functions.sh
+++ b/src/functions.sh
@@ -292,7 +292,7 @@ execute_shellcheck () {
 # Function to check if the action is run in a Debug mode
 is_debug () {
   local result
-  result=$(is_true "${RUNNER_DEBUG}")
+  result=$(is_true "${RUNNER_DEBUG:-0}")
 
   # shellcheck disable=SC2086
   # return require numeric value


### PR DESCRIPTION
It doesn't work as expected. Also, the debug output is not very useful.

It fixes the issue when matched strings are outputted into the console:

```
#!/bin/bash
#!/bin/bash
#!/bin/bash
#!/bin/bash
#!/bin/bash
#!/bin/bash
#!/bin/bash


:::::::::::::::::::::
::: Used Versions :::
:::::::::::::::::::::

ShellCheck: 0.9.0
csutils: 3.0.4


:::::::::::::::::::::::::::::::
::: Differential ShellCheck :::
:::::::::::::::::::::::::::::::

📜 List of shell scripts for scanning

ℹ️ No Fixes!

🥳 No defects added. Yay!

✅ SARIF report was successfully uploaded to GitHub
```