### PR TITLE
Improve shell script detection based on emacs file mode header :tiger:  

### DIFF
--- a/src/functions.sh
+++ b/src/functions.sh
@@ -142,7 +142,7 @@ has_shebang () {
   fi
 
   # Emacs mode detection
-  if grep --quiet -E '^\s*#\s+-\*-\s+(sh|ash|bash|dash|ksh|bats)\s+-\*-\s*' "${file}"; then
+  if grep --quiet -E '^\s*#.*\s+-\*-\s+(sh|ash|bash|dash|ksh|bats|shell-script)\s+-\*-\s*' "${file}"; then
     return 0
   fi
 

--- a/src/functions.sh
+++ b/src/functions.sh
@@ -142,7 +142,7 @@ has_shebang () {
   fi
 
   # Emacs mode detection
-  if grep --quiet -E '^\s*#.*\s+-\*-\s+(sh|ash|bash|dash|ksh|bats|shell-script)\s+-\*-\s*' "${file}"; then
+  if grep --quiet -E '^\s*#.*\s+-\*-\s+(mode:\s+)?(sh|ash|bash|dash|ksh|bats|shell-script)\s+-\*-\s*' "${file}"; then
     return 0
   fi
 

--- a/test/has_shebang.bats
+++ b/test/has_shebang.bats
@@ -250,6 +250,7 @@ setup () {
     '   # -*- sh -*-'
     '   # -*-  sh  -*-'
     ' #  -*-  sh  -*- ... ...'
+    '# systemd-sysext(8) completion  -*- shell-script -*-'
   )
   local emacs_incorrect=(
     ' -*- sh -*-'

--- a/test/has_shebang.bats
+++ b/test/has_shebang.bats
@@ -250,7 +250,7 @@ setup () {
     '   # -*- sh -*-'
     '   # -*-  sh  -*-'
     ' #  -*-  sh  -*- ... ...'
-    '# systemd-sysext(8) completion  -*- shell-script -*-'
+    '# systemd-sysext(8) completion  -*- mode: shell-script -*-'
   )
   local emacs_incorrect=(
     ' -*- sh -*-'


### PR DESCRIPTION
- add support for headers with `mode:` - e.g. `-*- mode: sh -*-`
- add support for headers with `shell script` key