### PR TITLE
Fix curl Argument list too long by using a payload.json file

### DIFF
--- a/src/functions.sh
+++ b/src/functions.sh
@@ -306,13 +306,15 @@ is_debug () {
 uploadSARIF () {
   is_debug && local verbose=--verbose
 
+  echo '{"commit_oid":"'"${HEAD}"'","ref":"'"${GITHUB_REF//merge/head}"'","analysis_key":"differential-shellcheck","sarif":"'"$(gzip -c output.sarif | base64 -w0)"'","tool_names":["differential-shellcheck"]}' > payload.json
+
   local curl_args=(
     "${verbose:---silent}"
     -X PUT
     -f "https://api.github.com/repos/${GITHUB_REPOSITORY}/code-scanning/analysis"
     -H "Authorization: token ${INPUT_TOKEN}"
     -H "Accept: application/vnd.github.v3+json"
-    -d '{"commit_oid":"'"${HEAD}"'","ref":"'"${GITHUB_REF//merge/head}"'","analysis_key":"differential-shellcheck","sarif":"'"$(gzip -c output.sarif | base64 -w0)"'","tool_names":["differential-shellcheck"]}'
+    -d "@payload.json"
   )
 
   if curl "${curl_args[@]}" &> curl_std; then


### PR DESCRIPTION
Should fix #375.

Tested by uploading the payload via curl to an httpd server using `curl -d '<json string>'`, which failed, and by using the payload.json which succeded. Also tested from the docker image.