### PR TITLE
Update csdiff to `3.2.2` :rocket: 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ FROM fedora@sha256:4e007f288dce23966216be81ef62ba05d139b9338f327c1d1c73b7167dd47
 ARG fedora="40"
 ARG arch="x86_64"
 
-ARG version_csdiff="3.2.1-1"
+ARG version_csdiff="3.2.2-1"
 ARG version_shellcheck="0.9.0-6"
 
 ARG rpm_csdiff="csdiff-${version_csdiff}.fc${fedora}.${arch}.rpm"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Next release
 
+## v5.2.0
+
+* Update `csutils` (`csdiff`) to 3.2.2
+  * propagate the imp flag as level in the SARIF format
+  * propagate endLine/endColumn in the JSON and SARIF formats
+
 ## v5.1.2
 
 * Fix curl Argument list too long by using a payload.json file - by @mpoberezhniy

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -7,7 +7,7 @@ FROM fedora@sha256:4e007f288dce23966216be81ef62ba05d139b9338f327c1d1c73b7167dd47
 ARG fedora="40"
 ARG arch="x86_64"
 
-ARG version_csdiff="3.2.1-1"
+ARG version_csdiff="3.2.2-1"
 ARG version_shellcheck="0.9.0-6"
 
 ARG rpm_csdiff="csdiff-${version_csdiff}.fc${fedora}.${arch}.rpm"

--- a/test/fixtures/get_defects/defects.log
+++ b/test/fixtures/get_defects/defects.log
@@ -10,6 +10,7 @@
                     "file_name": "innocent-script.sh",
                     "line": 7,
                     "column": 1,
+                    "h_size": 11,
                     "event": "warning[SC2034]",
                     "message": "UNUSED_VAR2 appears unused. Verify use (or export if used externally).",
                     "verbosity_level": 0
@@ -26,6 +27,7 @@
                     "file_name": "innocent-script.sh",
                     "line": 11,
                     "column": 8,
+                    "h_size": 17,
                     "event": "warning[SC2115]",
                     "message": "Use \"${var:?}\" to ensure this never expands to / .",
                     "verbosity_level": 0

--- a/test/fixtures/get_fixes/fixes.log
+++ b/test/fixtures/get_fixes/fixes.log
@@ -10,6 +10,7 @@
                     "file_name": "innocent-script.sh",
                     "line": 6,
                     "column": 1,
+                    "h_size": 10,
                     "event": "warning[SC2034]",
                     "message": "UNUSED_VAR appears unused. Verify use (or export if used externally).",
                     "verbosity_level": 0

--- a/test/show_versions.bats
+++ b/test/show_versions.bats
@@ -17,5 +17,5 @@ setup () {
   assert_success
   assert_output \
 "ShellCheck: 0.9.0
-csutils: 3.2.1"
+csutils: 3.2.2"
 }


### PR DESCRIPTION
* propagate the imp flag as level in the SARIF format
* propagate endLine/endColumn in the JSON and SARIF formats

Thank you @kdudka and @lzaoral 