### PR TITLE
Embed code context into SARIF output :feet: 

### DIFF
--- a/src/index.sh
+++ b/src/index.sh
@@ -101,6 +101,7 @@ shellcheck_version=$(get_shellcheck_version)
 # GitHub requires an absolute path, so let's remove the './' prefix from it.
 csgrep \
   --strip-path-prefix './' \
+  --embed-context 4 \
   --mode=sarif \
   --set-scan-prop='tool:ShellCheck' \
   --set-scan-prop="tool-version:${shellcheck_version}" \


### PR DESCRIPTION
This is preparation for Fingerprints, which are coming in the next version of csdiff.

- https://github.com/csutils/csdiff/pull/168

> It hashes the data that csdiff uses in its matching algorithm
> and the line content without spaces. For this fingerprint to
> be computed, the results need to include the line content for
> the key event in the format produced by `csgrep --embed-context`.