### PR TITLE
Update to csdiff 3.3.0 :feet: 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ FROM fedora@sha256:4e007f288dce23966216be81ef62ba05d139b9338f327c1d1c73b7167dd47
 ARG fedora="40"
 ARG arch="x86_64"
 
-ARG version_csdiff="3.2.2-1"
+ARG version_csdiff="3.3.0-1"
 ARG version_shellcheck="0.9.0-6"
 
 ARG rpm_csdiff="csdiff-${version_csdiff}.fc${fedora}.${arch}.rpm"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Next release
 
+* Add support for different display engines (`csgrep`, `sarif-fmt`)
+* Update `csutils` (`csdiff`) to 3.3.0
+  * `csdiff`: match findings by line content without spaces if available
+  * `csgrep --hash-v1`: match `csdiff/v1` fingerprint prefix
+  * `sarif`: initial implementation of `csdiff/v1` fingerprints
+  * `sarif`: add descriptions for ShellCheck rules
+
 ## v5.2.0
 
 * Provide `html` output with detected defects

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -7,7 +7,7 @@ FROM fedora@sha256:4e007f288dce23966216be81ef62ba05d139b9338f327c1d1c73b7167dd47
 ARG fedora="40"
 ARG arch="x86_64"
 
-ARG version_csdiff="3.2.2-1"
+ARG version_csdiff="3.3.0-1"
 ARG version_shellcheck="0.9.0-6"
 
 ARG rpm_csdiff="csdiff-${version_csdiff}.fc${fedora}.${arch}.rpm"

--- a/test/fixtures/generate_SARIF/test.sarif
+++ b/test/fixtures/generate_SARIF/test.sarif
@@ -26,9 +26,15 @@
                                 ]
                             },
                             "name": "SC2034",
+                            "shortDescription": {
+                                "text": "SC2034"
+                            },
                             "help": {
                                 "text": "Defect reference: https://github.com/koalaman/shellcheck/wiki/SC2034",
                                 "markdown": "Defect reference: [SC2034](https://github.com/koalaman/shellcheck/wiki/SC2034)"
+                            },
+                            "fullDescription": {
+                                "text": "Defect reference: https://github.com/koalaman/shellcheck/wiki/SC2034"
                             }
                         },
                         {
@@ -39,9 +45,15 @@
                                 ]
                             },
                             "name": "SC2115",
+                            "shortDescription": {
+                                "text": "SC2115"
+                            },
                             "help": {
                                 "text": "Defect reference: https://github.com/koalaman/shellcheck/wiki/SC2115",
                                 "markdown": "Defect reference: [SC2115](https://github.com/koalaman/shellcheck/wiki/SC2115)"
+                            },
+                            "fullDescription": {
+                                "text": "Defect reference: https://github.com/koalaman/shellcheck/wiki/SC2115"
                             }
                         }
                     ]
@@ -98,7 +110,10 @@
                                 }
                             ]
                         }
-                    ]
+                    ],
+                    "fingerprints": {
+                        "csdiff/v0": "64c37c2cd555f4d61c6e05ebd224beb8147d77bf"
+                    }
                 },
                 {
                     "ruleId": "SHELLCHECK_WARNING: warning[SC2115]",
@@ -150,7 +165,10 @@
                                 }
                             ]
                         }
-                    ]
+                    ],
+                    "fingerprints": {
+                        "csdiff/v0": "d9a3f3f1027ba2a0ca5dc7eb24d7d8b09dbe2b1d"
+                    }
                 },
                 {
                     "ruleId": "SHELLCHECK_WARNING: warning[SC2115]",
@@ -202,7 +220,10 @@
                                 }
                             ]
                         }
-                    ]
+                    ],
+                    "fingerprints": {
+                        "csdiff/v0": "d9a3f3f1027ba2a0ca5dc7eb24d7d8b09dbe2b1d"
+                    }
                 }
             ]
         }

--- a/test/is_github_actions.bats
+++ b/test/is_github_actions.bats
@@ -12,6 +12,7 @@ setup () {
 
 @test "is_github_actions()" {
   source "${PROJECT_ROOT}/src/functions.sh"
+  GITHUB_ACTIONS=
 
   run is_github_actions
   assert_failure 1

--- a/test/show_versions.bats
+++ b/test/show_versions.bats
@@ -17,5 +17,5 @@ setup () {
   assert_success
   assert_output \
 "ShellCheck: 0.9.0
-csutils: 3.2.2"
+csutils: 3.3.0"
 }


### PR DESCRIPTION
* csdiff: match findings by line content without spaces if available
* csgrep --hash-v1: match csdiff/v1 fingerprint prefix
* sarif: initial implementation of csdiff/v1 fingerprints
* sarif: add descriptions for ShellCheck rules

https://github.com/csutils/csdiff/releases/tag/csdiff-3.3.0

Huge Thanks to @kdudka and @lzaoral