### PR TITLE
Support `merge_group` event natively

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ The token needs to have the following [permissions](https://docs.github.com/en/r
 
 Differential ShellCheck exposes following [outputs](https://docs.github.com/en/actions/using-jobs/defining-outputs-for-jobs).
 
-### sarif
+### `sarif`
 
 Relative path to the SARIF file containing detected defects. Example of how to use `sarif` output within the workflow:
 
@@ -378,7 +378,7 @@ Relative path to the SARIF file containing detected defects. Example of how to u
 >
 > `sarif` output can be used together with tools like [`microsoft/sarif-tools`](https://github.com/microsoft/sarif-tools?tab=readme-ov-file#sarif-tools) to convert SARIF to other formats like `codeclimate`, `csv`, `docx` and more. [Example of use](https://github.com/microsoft/sarif-tools?tab=readme-ov-file#suggested-usage-in-ci-pipelines).
 
-### html
+### `html`
 
 Relative path to the HTML file containing detected defects. Example of how to use `html` output within the workflow:
 
@@ -409,14 +409,14 @@ _Code scanning is available for all public repositories on GitHub.com. Code scan
 
 ## Using with Visual Studio Code
 
-Differential ShellCheck doesn't have a VS Code plugin, but results can be accessed by using [SARIF Viewer](https://marketplace.visualstudio.com/items?itemName=MS-SarifVSCode.sarif-viewer) VS Code extension provided by Microsoft. Once installed, you have to connect your GitHub account with VS Code. Then, if you open a repository that uses Differential ShellCheck, you will see reported defects directly in your VS Code IDE.
+Differential ShellCheck doesn't have a Visual Studio Code plugin, but results can be accessed by using [SARIF Viewer](https://marketplace.visualstudio.com/items?itemName=MS-SarifVSCode.sarif-viewer) Visual Studio Code extension provided by Microsoft. Once installed, you have to connect your GitHub account with Visual Studio Code. Then, if you open a repository that uses Differential ShellCheck, you will see reported defects directly in your Visual Studio Code IDE.
 
 <p align="center">
-  <img src="docs/images/vs-code-sarif-connect-dark.png" width="450" alt="VS Code SARIF connect" />
+  <img src="docs/images/vs-code-sarif-connect-dark.png" width="450" alt="Visual Studio Code SARIF connect" />
 </p>
 
 <p align="center">
-  <img src="docs/images/vs-code-sarif-results-dark.png" width="550" alt="VS Code SARIF results" />
+  <img src="docs/images/vs-code-sarif-results-dark.png" width="550" alt="Visual Studio Code SARIF results" />
 </p>
 
 ## Limitations

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Action currently accepts following options:
 
 ### triggering-event
 
-The name of the event that triggered the workflow run. Supported values are: `pull_request`, `push` and `manual`.
+The name of the event that triggered the workflow run. Supported values are: `merge_group`, `pull_request`, `push` and `manual`.
 
 * default value: `${{ github.event_name }}`
 * requirements: `optional`
@@ -204,6 +204,20 @@ The name of the event that triggered the workflow run. Supported values are: `pu
 `SHA1` of the commit which refers to the `HEAD` of changes. Input is used only when `triggering-event` is set to `manual`.
 
 * default value: `undefined`
+* requirements: `optional`
+
+### merge-group-base
+
+`SHA1` of the merge group's parent commit. Input is used when `triggering-event` is set to `merge_group`.
+
+* default value: `${{ github.event.merge_group.base_sha }}`
+* requirements: `optional`
+
+### merge-group-head
+
+`SHA1` of the merge group commit. Input is used when `triggering-event` is set to `merge_group`.
+
+* default value: `${{ github.event.merge_group.head_sha }}`
 * requirements: `optional`
 
 ### pull-request-base
@@ -242,6 +256,7 @@ Default types of scans based on `triggering-event` input:
 
 | `triggering-event` | type of scan               |
 |--------------------|----------------------------|
+| `merge_group`      | differential               |
 | `pull_request`     | differential               |
 | `push`             | full                       |
 | `manual`           | based on `diff-scan` input |

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ branding:
 
 inputs:
   triggering-event:
-    description: The name of the event that triggered the workflow run. Supported values are (pull_request | push | manual).
+    description: The name of the event that triggered the workflow run. Supported values are (merge_group | pull_request | push | manual).
     required: false
     default: ${{ github.event_name }}
 
@@ -22,6 +22,15 @@ inputs:
     description: Hash of head commit. This input is used when triggering-event is set to "manual".
     required: false
     default: ""
+
+  merge-group-base:
+    description: Hash of the merge group's parent commit. This input is used when triggering-event is set to "merge_group".
+    required: false
+    default: ${{ github.event.merge_group.base_sha }}
+  merge-group-head:
+    description: Hash of the merge group commit. This input is used when triggering-event is set to "merge_group".
+    required: false
+    default: ${{ github.event.merge_group.head_sha }}
 
   pull-request-base:
     description: Hash of top commit on base branch. This input is used when triggering-event is set to "pull_request".
@@ -96,6 +105,8 @@ runs:
   image: docker://ghcr.io/redhat-plumbers-in-action/differential-shellcheck:v5.3.1
   env:
     INPUT_TRIGGERING_EVENT: ${{ inputs.triggering-event }}
+    INPUT_MERGE_GROUP_BASE: ${{ inputs.merge-group-base }}
+    INPUT_MERGE_GROUP_HEAD: ${{ inputs.merge-group-head }}
     INPUT_PULL_REQUEST_BASE: ${{ inputs.pull-request-base }}
     INPUT_PULL_REQUEST_HEAD: ${{ inputs.pull-request-head }}
     INPUT_PUSH_EVENT_BASE: ${{ inputs.push-event-base }}

--- a/src/functions.sh
+++ b/src/functions.sh
@@ -11,6 +11,10 @@
 # $? - return value - 0 on success
 is_full_scan_demanded () {
   case "${INPUT_TRIGGERING_EVENT-${GITHUB_EVENT_NAME}}" in
+    "merge_group")
+      return 1
+      ;;
+
     "push")
       return 0
       ;;
@@ -44,6 +48,12 @@ is_strict_check_on_push_demanded () {
 # $? - return value - 0 on success
 pick_base_and_head_hash () {
   case ${INPUT_TRIGGERING_EVENT-${GITHUB_EVENT_NAME}} in
+    "merge_group")
+      export BASE=${INPUT_MERGE_GROUP_BASE:-}
+      export HEAD=${INPUT_MERGE_GROUP_HEAD:-}
+      is_unit_tests && echo "BASE:\"${BASE}\" ; HEAD:\"${HEAD}\""
+      ;;
+
     "push")
       export BASE=${INPUT_PUSH_EVENT_BASE:-}
       export HEAD=${INPUT_PUSH_EVENT_HEAD:-}
@@ -63,7 +73,7 @@ pick_base_and_head_hash () {
     ;;
 
     *)
-      echo -e "❓ ${RED}Value of required variable INPUT_TRIGGERING_EVENT isn't set or contains unsupported value. Supported values are: (pull_request | push | manual).${NOCOLOR}"
+      echo -e "❓ ${RED}Value of required variable INPUT_TRIGGERING_EVENT isn't set or contains unsupported value. Supported values are: (merge_group | pull_request | push | manual).${NOCOLOR}"
       return 1
   esac
 
@@ -96,7 +106,7 @@ get_scripts_for_scanning () {
     has_shebang "${file}" && scripts_for_scanning+=("./${file}")
   done
 
-  eval $output=\("${scripts_for_scanning[*]@Q}"\)
+  eval "${output}"=\("${scripts_for_scanning[*]@Q}"\)
   is_unit_tests && eval echo "\${${output}[@]@Q}"
 }
 

--- a/test/is_full_scan_demanded.bats
+++ b/test/is_full_scan_demanded.bats
@@ -10,6 +10,15 @@ setup () {
   load 'test_helper/bats-support/load'
 }
 
+@test "is_full_scan_demanded() - trigger event = merge_group" {
+  source "${PROJECT_ROOT}/src/functions.sh"
+
+  INPUT_TRIGGERING_EVENT="merge_group"
+
+  run is_full_scan_demanded
+  assert_failure 1
+}
+
 @test "is_full_scan_demanded() - trigger event = push" {
   source "${PROJECT_ROOT}/src/functions.sh"
 

--- a/test/is_strict_check_on_push_demanded.bats
+++ b/test/is_strict_check_on_push_demanded.bats
@@ -10,6 +10,28 @@ setup () {
   load 'test_helper/bats-support/load'
 }
 
+@test "is_strict_check_on_push_demanded() - trigger event = merge_group" {
+  source "${PROJECT_ROOT}/src/functions.sh"
+
+  INPUT_TRIGGERING_EVENT="merge_group"
+  INPUT_STRICT_CHECK_ON_PUSH=""
+
+  run is_strict_check_on_push_demanded
+  assert_failure 1
+
+  INPUT_TRIGGERING_EVENT="merge_group"
+  INPUT_STRICT_CHECK_ON_PUSH="false"
+
+  run is_strict_check_on_push_demanded
+  assert_failure 1
+
+  INPUT_TRIGGERING_EVENT="merge_group"
+  INPUT_STRICT_CHECK_ON_PUSH="true"
+
+  run is_strict_check_on_push_demanded
+  assert_failure 1
+}
+
 @test "is_strict_check_on_push_demanded() - trigger event = push" {
   source "${PROJECT_ROOT}/src/functions.sh"
 

--- a/test/pick_base_and_head_hash.bats
+++ b/test/pick_base_and_head_hash.bats
@@ -10,6 +10,36 @@ setup () {
   load 'test_helper/bats-support/load'
 }
 
+@test "pick_base_and_head_hash() - trigger event = merge_group" {
+  source "${PROJECT_ROOT}/src/functions.sh"
+
+  INPUT_TRIGGERING_EVENT="merge_group"
+
+  run pick_base_and_head_hash
+  assert_failure 2
+
+  INPUT_MERGE_GROUP_BASE=""
+
+  run pick_base_and_head_hash
+  assert_failure 2
+
+  INPUT_MERGE_GROUP_HEAD=""
+
+  run pick_base_and_head_hash
+  assert_failure 2
+
+  UNIT_TESTS="true"
+  INPUT_MERGE_GROUP_BASE="abcdef123456"
+  INPUT_MERGE_GROUP_HEAD="ghijkl789012"
+
+  run pick_base_and_head_hash
+  assert_success
+  assert_output "BASE:\"${INPUT_MERGE_GROUP_BASE}\" ; HEAD:\"${INPUT_MERGE_GROUP_HEAD}\""
+  # TODO: Doesn't work, don't know why...
+  # assert_equal "\"${BASE}\"" "\"${INPUT_MERGE_GROUP_BASE}\""
+  # assert_equal "\"${HEAD}\"" "\"${INPUT_MERGE_GROUP_HEAD}\""
+}
+
 @test "pick_base_and_head_hash() - trigger event = push" {
   source "${PROJECT_ROOT}/src/functions.sh"
 
@@ -123,6 +153,8 @@ teardown () {
   export \
     INPUT_TRIGGERING_EVENT="" \
     GITHUB_EVENT_NAME="" \
+    INPUT_MERGE_GROUP_BASE="" \
+    INPUT_MERGE_GROUP_HEAD="" \
     INPUT_PUSH_EVENT_BASE="" \
     INPUT_PUSH_EVENT_HEAD="" \
     INPUT_PULL_REQUEST_BASE="" \


### PR DESCRIPTION
# What

Support `merge_group` event natively.

# Why

Closes #432

Our team uses [the merge queue](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue) to serialize and validate changes on the default branch. I want to run ShellCheck when a change is added to the merge queue so that I can detect problems introduced by a bad merge before pushing them to the default branch.

While I can configure the workflow to use "manual" triggering event with the base & head SHAs, it'd be convenient if the workflow natively support `merge_group`.

# How tested

Will see the CI test results.

# References

The definition of `merge_group` event.
https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#merge_group