### PR TITLE
Run differential ShellCheck on merge_group

### DIFF
--- a/.github/workflows/differential-shellcheck.yml
+++ b/.github/workflows/differential-shellcheck.yml
@@ -5,6 +5,9 @@ on:
   push:
   pull_request:
     branches: [ main ]
+  merge_group:
+    branches:
+      - main
 
 permissions:
   contents: read
@@ -43,6 +46,9 @@ jobs:
             src/**.{zsh,osh}
           display-engine: sarif-fmt
           token: ${{ secrets.GITHUB_TOKEN }}
+          triggering-event: ${{ github.event_name == 'merge_group' && 'manual' || github.event_name }}
+          base: ${{ github.event.merge_group.base_sha }}
+          head: ${{ github.event.merge_group.head_sha }}
 
       - if: always()
         name: Upload artifact with defects in SARIF format


### PR DESCRIPTION
# What

Run differential-shellcheck on a [`merge_group` GitHub event](https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=checks_requested#merge_group), which will be fired when a change is added to the merge queue.

# Why

For #433, we want to know what `link_to_results` would be for the code scanning result triggered by a `merge_group` event. We need to try running the workflow on a `merge_group` event (without #433).

# How tested

An equivalent change works in our private repository.