### PR TITLE
Update Differential ShellCheck workflow

### DIFF
--- a/.github/workflows/differential-shellcheck.yml
+++ b/.github/workflows/differential-shellcheck.yml
@@ -3,6 +3,7 @@
 name: Differential ShellCheck
 on:
   push:
+    branches: [ main ]
   pull_request:
     branches: [ main ]
   merge_group:

--- a/.github/workflows/differential-shellcheck.yml
+++ b/.github/workflows/differential-shellcheck.yml
@@ -6,15 +6,14 @@ on:
   pull_request:
     branches: [ main ]
   merge_group:
-    branches:
-      - main
+    types: [ checks_requested ]
 
 permissions:
   contents: read
 
 jobs:
   lint:
-    name: Test latest changes
+    name: Differential ShellCheck - test current changes
     runs-on: ubuntu-latest
 
     permissions:
@@ -46,9 +45,6 @@ jobs:
             src/**.{zsh,osh}
           display-engine: sarif-fmt
           token: ${{ secrets.GITHUB_TOKEN }}
-          triggering-event: ${{ github.event_name == 'merge_group' && 'manual' || github.event_name }}
-          base: ${{ github.event.merge_group.base_sha }}
-          head: ${{ github.event.merge_group.head_sha }}
 
       - if: always()
         name: Upload artifact with defects in SARIF format

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -6,6 +6,8 @@ on:
     branches: [ main ]
   push:
     branches: [ main ]
+  merge_group:
+    types: [ checks_requested ]
 
 permissions:
   contents: read

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -227,7 +227,7 @@
 
 * Bugfixes:
   * Make directory /github/workspace git-save
-  * Remove double quotes to avoid git empty pathspec warnings
+  * Remove double quotes to avoid `git` empty pathspec warnings
 * Make GA tests ran on current version of repo/fork
 * Bump actions/checkout from 2 to 3
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next release
 
+* Native support for `merge_group` trigger event
+
 ## v5.3.1
 
 * Update `csutils` (`csdiff`) to 3.4.0


### PR DESCRIPTION
Use default inputs when running on `merge_group`

Follow-up to:
- https://github.com/redhat-plumbers-in-action/differential-shellcheck/pull/434