### PR TITLE
Use Fedora 41 as base image & update ShellCheck to 0.10.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-FROM fedora@sha256:3ec60eb34fa1a095c0c34dd37cead9fd38afb62612d43892fcf1d3425c32bc1e
+FROM fedora:41@sha256:9cfb3a7ad0a36a1e943409def613ec495571a5683c45addb5d608c2c29bb8248
 
 # --- Version Pinning --- #
 
-ARG fedora="40"
+ARG fedora="41"
 ARG arch="x86_64"
 
-ARG version_csdiff="3.5.0-1"
-ARG version_shellcheck="0.9.0-6"
+ARG version_csdiff="3.5.2-1"
+ARG version_shellcheck="0.10.0-3"
 
 ARG rpm_csdiff="csdiff-${version_csdiff}.fc${fedora}.${arch}.rpm"
 

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,14 +1,14 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-FROM fedora@sha256:3ec60eb34fa1a095c0c34dd37cead9fd38afb62612d43892fcf1d3425c32bc1e
+FROM fedora:41@sha256:9cfb3a7ad0a36a1e943409def613ec495571a5683c45addb5d608c2c29bb8248
 
 # --- Version Pinning --- #
 
-ARG fedora="40"
+ARG fedora="41"
 ARG arch="x86_64"
 
-ARG version_csdiff="3.5.0-1"
-ARG version_shellcheck="0.9.0-6"
+ARG version_csdiff="3.5.2-1"
+ARG version_shellcheck="0.10.0-3"
 
 ARG rpm_csdiff="csdiff-${version_csdiff}.fc${fedora}.${arch}.rpm"
 

--- a/test/fixtures/generate_SARIF/test.sarif
+++ b/test/fixtures/generate_SARIF/test.sarif
@@ -6,7 +6,7 @@
             "externalizedProperties": {
                 "tool": "ShellCheck",
                 "tool-url": "https://www.shellcheck.net/wiki/",
-                "tool-version": "0.9.0"
+                "tool-version": "0.10.0"
             }
         }
     ],
@@ -15,7 +15,7 @@
             "tool": {
                 "driver": {
                     "name": "ShellCheck",
-                    "version": "0.9.0",
+                    "version": "0.10.0",
                     "informationUri": "https://www.shellcheck.net/wiki/",
                     "rules": [
                         {

--- a/test/show_versions.bats
+++ b/test/show_versions.bats
@@ -16,6 +16,6 @@ setup () {
   run show_versions
   assert_success
   assert_output \
-"ShellCheck: 0.9.0
-csutils: 3.5.0"
+"ShellCheck: 0.10.0
+csutils: 3.5.2"
 }


### PR DESCRIPTION
use ShellCheck 0.10.0
use csdiff 3.5.2