### PR TITLE
fix: Pass INPUT_BASE and INPUT_HEAD to container for manual triggering-event

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -118,3 +118,5 @@ runs:
     INPUT_EXCLUDE_PATH: ${{ inputs.exclude-path }}
     INPUT_INCLUDE_PATH: ${{ inputs.include-path }}
     INPUT_DISPLAY_ENGINE: ${{ inputs.display-engine }}
+    INPUT_BASE: ${{ inputs.base }}
+    INPUT_HEAD: ${{ inputs.head }}


### PR DESCRIPTION
When using triggering-event "manual", `BASE` and `HEAD` are set in `pick_base_and_head_hash` function which expects respectively `INPUT_BASE` and `INPUT_HEAD` but they are not passed in action.yml

This result in the following error:
```
❓ Value of required variables BASE and/or HEAD isn't set or contains unsupported value.
```